### PR TITLE
[Feature] HealthCheck API 구현 close #7

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
 }
 
 tasks.named('test') {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,3 +10,12 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQL8Dialect
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health
+  endpoint:
+    health:
+      show-details: never

--- a/src/test/java/kr/co/csalgo/infrastructure/actuator/HealthCheckTest.java
+++ b/src/test/java/kr/co/csalgo/infrastructure/actuator/HealthCheckTest.java
@@ -1,0 +1,27 @@
+package kr.co.csalgo.infrastructure.actuator;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class HealthCheckTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    @DisplayName("헬스체크는 OK를 반환한다.")
+    void healthCheck() throws Exception {
+        mockMvc.perform(get("/actuator/health"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("UP"));
+    }
+}


### PR DESCRIPTION
<!-- (title: "[Type] Title close #IssueNumber") -->

## Motivation

<!-- 작성 배경 -->

- 서비스 가용성 점검을 위한 API 구현 필요성 대두
	- 추후 AWS ALB와 같은 로드밸런서에서 활용 가능성이 예상됨
- API 테스트 코드 예제 필요성 대두

## Problem Solving

<!-- 해결 방법 -->
- `spring-boot-actuator` 의존성 추가
- `application.yml`에 HealthCheck API 경로 설정
- HealthCheckTest 작성
	- API 테스트 코드 예제로 활용할 것

## To Reviewer

<!-- 리뷰어에게 말하고 싶은 것, 유의 깊게 봐주었으면 하는 것, 의문점 등 -->

- `spring-boot-actuator`란?
	- Spring Boot 애플리케이션의 운영 및 모니터링 기능을 제공하는 서브 모듈입니다.
	- 사전 정의된 엔드포인트를 통해 애플리케이션 상태를 확인할 수 있는 API를 자동으로 제공해줍니다.
	- 예를 들면, `/actuator/health` 엔드포인트에 접근하면 `HTTP 200` 상태 코드와 함께 서버 상태 정보를 Response Body로 응답합니다.
- Postman을 활용한 테스트 결과
	| 현재 적용 사항 (`show-details: never`) | `show-details: always` 설정 시 |
	| --- | --- |
	| <img width="685" alt="image" src="https://github.com/user-attachments/assets/65d3199e-3323-4579-9a24-0c814c185c7a" /> | <img width="557" alt="image" src="https://github.com/user-attachments/assets/6a1bb268-02c2-4d01-a639-78a8b1b3fc81" /> |

- 참고자료: [Toss - Spring Boot Actuator의 헬스체크 살펴보기](https://toss.tech/article/how-to-work-health-check-in-spring-boot-actuator)