### PR TITLE
[Feature] 구독 해지 API 구현 close #17

### DIFF
--- a/src/main/java/kr/co/csalgo/application/user/dto/UnsubscriptionUseCaseDto.java
+++ b/src/main/java/kr/co/csalgo/application/user/dto/UnsubscriptionUseCaseDto.java
@@ -1,0 +1,34 @@
+package kr.co.csalgo.application.user.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+
+public class UnsubscriptionUseCaseDto {
+    @Getter
+    public static class Request {
+        @NotNull(message = "사용자 ID는 필수입니다.")
+        private final Long userId;
+
+        @Builder
+        public Request(Long userId) {
+            this.userId = userId;
+        }
+    }
+
+    @Getter
+    public static class Response {
+        private final String message;
+
+        @Builder
+        public Response(String message) {
+            this.message = message;
+        }
+
+        public static Response of() {
+            return Response.builder()
+                    .message("구독이 성공적으로 해지되었습니다.")
+                    .build();
+        }
+    }
+}

--- a/src/main/java/kr/co/csalgo/application/user/dto/UnsubscriptionUseCaseDto.java
+++ b/src/main/java/kr/co/csalgo/application/user/dto/UnsubscriptionUseCaseDto.java
@@ -1,11 +1,13 @@
 package kr.co.csalgo.application.user.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Getter;
 
 public class UnsubscriptionUseCaseDto {
     @Getter
+    @Schema(name = "UnSubscriptionUseCaseDto.Request")
     public static class Request {
         @NotNull(message = "사용자 ID는 필수입니다.")
         private final Long userId;
@@ -17,6 +19,7 @@ public class UnsubscriptionUseCaseDto {
     }
 
     @Getter
+    @Schema(name = "UnSubscriptionUseCaseDto.Response")
     public static class Response {
         private final String message;
 

--- a/src/main/java/kr/co/csalgo/application/user/usecase/SubscriptionUseCase.java
+++ b/src/main/java/kr/co/csalgo/application/user/usecase/SubscriptionUseCase.java
@@ -1,6 +1,7 @@
 package kr.co.csalgo.application.user.usecase;
 
 import kr.co.csalgo.application.user.dto.SubscriptionUseCaseDto;
+import kr.co.csalgo.application.user.dto.UnsubscriptionUseCaseDto;
 import kr.co.csalgo.domain.user.entity.User;
 import kr.co.csalgo.domain.user.service.UserService;
 import lombok.RequiredArgsConstructor;
@@ -17,4 +18,8 @@ public class SubscriptionUseCase {
         return SubscriptionUseCaseDto.Response.fromEntity(user);
     }
 
+    public UnsubscriptionUseCaseDto.Response unsubscribe(UnsubscriptionUseCaseDto.Request request) {
+        userService.delete(request.getUserId());
+        return UnsubscriptionUseCaseDto.Response.of();
+    }
 }

--- a/src/main/java/kr/co/csalgo/domain/user/service/UserService.java
+++ b/src/main/java/kr/co/csalgo/domain/user/service/UserService.java
@@ -23,6 +23,12 @@ public class UserService {
         return user;
     }
 
+    public void delete(Long id) {
+        User user = userRepository.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "이미 삭제된 사용자 혹은 존재하지 않는 사용자입니다."));
+        userRepository.delete(user);
+    }
+
     private void checkDuplicateEmail(String email) {
         if (userRepository.existsByEmail(email)) {
             throw new ResponseStatusException(HttpStatus.CONFLICT, ErrorCode.DUPLICATE_EMAIL.getMessage());

--- a/src/main/java/kr/co/csalgo/presentation/subscription/SubscriptionController.java
+++ b/src/main/java/kr/co/csalgo/presentation/subscription/SubscriptionController.java
@@ -6,13 +6,12 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import kr.co.csalgo.application.user.dto.SubscriptionUseCaseDto;
+import kr.co.csalgo.application.user.dto.UnsubscriptionUseCaseDto;
 import kr.co.csalgo.application.user.usecase.SubscriptionUseCase;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -30,5 +29,16 @@ public class SubscriptionController {
     })
     public ResponseEntity<?> registerUser(@Valid @RequestBody SubscriptionUseCaseDto.Request request) {
         return ResponseEntity.ok(subscriptionUseCase.create(request));
+    }
+
+    @DeleteMapping
+    @Operation(summary = "구독 해지", description = "사용자가 이메일을 통해 구독을 해지할 수 있습니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "구독 해지 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 (유효성 검사 실패)"),
+            @ApiResponse(responseCode = "404", description = "구독 정보 없음")
+    })
+    public ResponseEntity<?> unsubscribe(@Valid @ParameterObject UnsubscriptionUseCaseDto.Request request) {
+        return ResponseEntity.ok(subscriptionUseCase.unsubscribe(request));
     }
 }

--- a/src/test/java/kr/co/csalgo/application/user/usecase/SubscriptionUseCaseTest.java
+++ b/src/test/java/kr/co/csalgo/application/user/usecase/SubscriptionUseCaseTest.java
@@ -1,0 +1,41 @@
+package kr.co.csalgo.application.user.usecase;
+
+import kr.co.csalgo.application.user.dto.UnsubscriptionUseCaseDto;
+import kr.co.csalgo.domain.user.service.UserService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.Mockito.verify;
+
+@DisplayName("SubscriptionUseCase Test")
+@ExtendWith(MockitoExtension.class)
+class SubscriptionUseCaseTest {
+    @Mock
+    private UserService userService;
+    private SubscriptionUseCase subscriptionUseCase;
+
+    @BeforeEach
+    void setUp() {
+        subscriptionUseCase = new SubscriptionUseCase(userService);
+    }
+
+    @Test
+    @DisplayName("구독 삭제 테스트")
+    void testUnsubscribe() {
+        // given
+        Long id = 1L;
+        UnsubscriptionUseCaseDto.Request request = UnsubscriptionUseCaseDto.Request.builder()
+                .userId(id)
+                .build();
+
+        // when
+        UnsubscriptionUseCaseDto.Response response = subscriptionUseCase.unsubscribe(request);
+
+        // then
+        verify(userService).delete(id);
+    }
+}

--- a/src/test/java/kr/co/csalgo/domain/user/service/UserServiceTest.java
+++ b/src/test/java/kr/co/csalgo/domain/user/service/UserServiceTest.java
@@ -5,7 +5,9 @@ import kr.co.csalgo.domain.user.repository.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.util.Optional;
@@ -16,6 +18,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @DisplayName("UserService Test")
+@ExtendWith(MockitoExtension.class)
 class UserServiceTest {
     @Mock
     private UserRepository userRepository;
@@ -33,26 +36,26 @@ class UserServiceTest {
         // given
         String email = "team.jjins@gmail.com";
         User user = new User(email);
-        when(userRepository.findByEmail(email)).thenReturn(Optional.of(user));
+        when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
 
         // when
-        userService.delete(email);
+        userService.delete(user.getId());
 
         // then
         assertFalse(userRepository.existsByEmail(email));
-        verify(userRepository.delete(user));
+        verify(userRepository).delete(user);
     }
 
     @Test
     @DisplayName("존재하지 않는 사용자를 삭제할 때 예외가 발생한다.")
     void testUserDeleteFail() {
         // given
-        String email = "team.jjins@gmail.com";
-        when(userRepository.findByEmail(email)).thenReturn(Optional.empty());
+        Long unregisteredUserId = 999L;
+        when(userRepository.findById(unregisteredUserId)).thenReturn(Optional.empty());
 
         // when
         assertThrows(ResponseStatusException.class, () -> {
-            userService.delete(email);
+            userService.delete(unregisteredUserId);
         });
     }
 }

--- a/src/test/java/kr/co/csalgo/domain/user/service/UserServiceTest.java
+++ b/src/test/java/kr/co/csalgo/domain/user/service/UserServiceTest.java
@@ -1,0 +1,58 @@
+package kr.co.csalgo.domain.user.service;
+
+import kr.co.csalgo.domain.user.entity.User;
+import kr.co.csalgo.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@DisplayName("UserService Test")
+class UserServiceTest {
+    @Mock
+    private UserRepository userRepository;
+    private UserService userService;
+
+    @BeforeEach
+    void setUp() {
+        userService = new UserService(userRepository);
+    }
+
+
+    @Test
+    @DisplayName("존재하는 사용자를 성공적으로 삭제한다.")
+    void testUserDeleteSuccess() {
+        // given
+        String email = "team.jjins@gmail.com";
+        User user = new User(email);
+        when(userRepository.findByEmail(email)).thenReturn(Optional.of(user));
+
+        // when
+        userService.delete(email);
+
+        // then
+        assertFalse(userRepository.existsByEmail(email));
+        verify(userRepository.delete(user));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 사용자를 삭제할 때 예외가 발생한다.")
+    void testUserDeleteFail() {
+        // given
+        String email = "team.jjins@gmail.com";
+        when(userRepository.findByEmail(email)).thenReturn(Optional.empty());
+
+        // when
+        assertThrows(ResponseStatusException.class, () -> {
+            userService.delete(email);
+        });
+    }
+}

--- a/src/test/java/kr/co/csalgo/presentation/subscription/SubscriptionControllerTest.java
+++ b/src/test/java/kr/co/csalgo/presentation/subscription/SubscriptionControllerTest.java
@@ -10,10 +10,13 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.server.ResponseStatusException;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -53,6 +56,14 @@ public class SubscriptionControllerTest {
         SubscriptionUseCaseDto.Request request = SubscriptionUseCaseDto.Request.builder()
                 .email("duplicate@gmail.com")
                 .build();
+
+        SubscriptionUseCaseDto.Response response = SubscriptionUseCaseDto.Response.builder()
+                .subscriptionId(1L)
+                .build();
+
+        when(subscriptionUseCase.create(any()))
+                .thenReturn(response)
+                .thenThrow(new ResponseStatusException(HttpStatus.CONFLICT, "이미 구독된 이메일입니다."));
 
         mockMvc.perform(post("/api/subscriptions")
                 .contentType(MediaType.APPLICATION_JSON)

--- a/src/test/java/kr/co/csalgo/presentation/subscription/SubscriptionControllerTest.java
+++ b/src/test/java/kr/co/csalgo/presentation/subscription/SubscriptionControllerTest.java
@@ -3,14 +3,19 @@ package kr.co.csalgo.presentation.subscription;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.transaction.Transactional;
 import kr.co.csalgo.application.user.dto.SubscriptionUseCaseDto;
+import kr.co.csalgo.application.user.dto.UnsubscriptionUseCaseDto;
+import kr.co.csalgo.application.user.usecase.SubscriptionUseCase;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -21,6 +26,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 public class SubscriptionControllerTest {
     @Autowired
     private MockMvc mockMvc;
+
+    @MockitoBean
+    private SubscriptionUseCase subscriptionUseCase;
 
     @Autowired
     private ObjectMapper mapper;
@@ -82,6 +90,26 @@ public class SubscriptionControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(mapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest())
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("구독 해지 성공")
+    void testUnsubscribeSuccess() throws Exception {
+        // given
+        UnsubscriptionUseCaseDto.Request request = UnsubscriptionUseCaseDto.Request.builder()
+                .userId(1L)
+                .build();
+        UnsubscriptionUseCaseDto.Response response = UnsubscriptionUseCaseDto.Response.of();
+
+        // when
+        when(subscriptionUseCase.unsubscribe(request)).thenReturn(response);
+
+        // then
+        mockMvc.perform(delete("/api/subscriptions")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .param("userId", String.valueOf(request.getUserId())))
+                .andExpect(status().isOk())
                 .andDo(print());
     }
 }


### PR DESCRIPTION
<!-- (title: "[Type] Title close #IssueNumber") -->

## Motivation

<!-- 작성 배경 -->

- resolve #17 
- 사용자가 더 이상 서비스를 이용하지 않도록 하기 위한 API 구현 필요성 대두
- 전반적인 테스트 코드 작성 예제 포함

## Problem Solving

<!-- 해결 방법 -->

- 구독 해지 API 구현 (fb548b60616c515b0d183d7e25913ea40a5a84cf)
- id(PK) 기반 사용자 삭제 로직 구현 (a31007d845260e51181a26ab78b3463d87c93284)

## To Reviewer

<!-- 리뷰어에게 말하고 싶은 것, 유의 깊게 봐주었으면 하는 것, 의문점 등 -->

### 실행 결과

| 정상 동작 | 오류 (존재하지 않는 ID) |
| --- | --- |
| <img width="530" alt="image" src="https://github.com/user-attachments/assets/9086f055-548a-4244-adcf-38d614daa342" /> | <img width="522" alt="image" src="https://github.com/user-attachments/assets/32250115-e8d9-468b-8f5e-b0c7bda58d5d" /> |

### 추가적인 이슈 발생

- 현재 삭제 시 Soft Delete가 아닌 Hard Delete 방식으로 동작하고 있습니다.
    - 원인은 `@SQLDelete(...)` 어노테이션을 상위 클래스(`AuditableEntity`)에 선언할 경우, 하위 엔티티(`User` 등)에는 반영되지 않기 때문입니다.
    - 해결 방안으로는 `@SQLDelete`와 `@SQLRestriction`을 각 하위 엔티티에 직접 선언해야 합니다.
    - 또는 Hibernate의 `@SQLDelete` 대신 JPA의 `@PreRemove` 콜백과 `SoftDeletable` 인터페이스를 활용한 방식도 고려할 수 있습니다.
    - 이슈 추가 해놓았습니다. (#24)