### PR TITLE
[Feature] 서비스 구독 모달 구현 close #21

### DIFF
--- a/src/main/resources/templates/fragments/modal/subscribe-modal.html
+++ b/src/main/resources/templates/fragments/modal/subscribe-modal.html
@@ -1,0 +1,56 @@
+<div th:fragment="subscribeModal">
+    <div class="modal fade" id="subscribeModal" tabindex="-1" aria-labelledby="subscribeModalLabel" aria-hidden="true">
+        <div class="modal-dialog modal-dialog-centered">
+            <div class="modal-content">
+
+                <div class="modal-header">
+                    <h5 class="modal-title" id="subscribeModalLabel">이메일 인증</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="닫기"></button>
+                </div>
+
+                <div class="modal-body">
+                    <form id="subscribeForm">
+                        <!-- 이메일 입력 -->
+                        <div class="mb-3">
+                            <label for="email" class="form-label">이메일 주소</label>
+                            <input type="email" class="form-control" id="email" name="email" required>
+                        </div>
+
+                        <!-- 인증 코드 전송 버튼 -->
+                        <div class="mb-3">
+                            <button type="button" class="btn btn-outline-primary w-100" id="sendCodeBtn">
+                                인증 코드 전송
+                            </button>
+                        </div>
+
+                        <!-- 인증 코드 입력 -->
+                        <div class="mb-3">
+                            <label for="code" class="form-label">인증 코드</label>
+                            <input type="text" class="form-control" id="code" name="code">
+                            <button type="button" class="btn btn-sm btn-secondary mt-2" id="verifyCodeBtn">
+                                인증 코드 검증
+                            </button>
+                            <div id="codeStatus" class="form-text text-success d-none">✅ 인증되었습니다.</div>
+                        </div>
+
+                        <!-- 개인정보 동의 -->
+                        <div class="form-check mb-3">
+                            <input class="form-check-input" type="checkbox" id="agreePolicy" name="agreePolicy">
+                            <label class="form-check-label" for="agreePolicy">
+                                <a href="/policy" target="_blank">개인정보 처리방침</a>에 동의합니다.
+                            </label>
+                        </div>
+                    </form>
+                </div>
+
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">닫기</button>
+                    <button type="submit" class="btn btn-primary" form="subscribeForm" id="submitBtn" disabled>
+                        확인
+                    </button>
+                </div>
+
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Index</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</head>
+<body class="p-4">
+
+<h1>📄 Index 페이지</h1>
+
+<button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#subscribeModal">
+    모달 열기
+</button>
+
+<!-- 모달 프래그먼트 포함 -->
+<div th:replace="fragments/modal/subscribe-modal :: subscribeModal"></div>
+
+</body>
+</html>


### PR DESCRIPTION
<!-- (title: "[Type] Title close #IssueNumber") -->

## Motivation

<!-- 작성 배경 -->

- resolve #21 
- 사용자가 서비스를 이용하기 위해, 진입점에서 개인정보(이메일 등) 입력을 통한 서비스 구독 기능 구현 필요성 대두
- 랜딩페이지에서 모달을 이용해 서비스 구독을 진행하고자 함

## Problem Solving

<!-- 해결 방법 -->

- Thymeleaf를 활용한 modal 페이지 구현
	- Bootstrap을 활용하여 CSS 설정
	- `<meta charset="UTF-8">` 설정을 통한 인코딩
- 임시 랜딩 페이지(`index.html`)을 작성하여 모달 정상 동작 테스트 진행

## To Reviewer

<!-- 리뷰어에게 말하고 싶은 것, 유의 깊게 봐주었으면 하는 것, 의문점 등 -->

<img width="524" alt="image" src="https://github.com/user-attachments/assets/75010305-72ba-41cd-8200-656bb7d25092" />

- IDE 프리뷰 서버 (IntelliJ Local HTTP Server)로 실행할 경우, 템플릿 엔진(Thymeleaf)이 실행되지 않기 때문에 정상적으로 동작하지 않습니다.
	- `http://localhost:8080`으로 실행하면 정상적으로 확인이 가능합니다.
- API 연동은 별도 이슈 생성하여 추후 진행하도록 하겠습니다.