### PR TITLE
[Chore]  브랜치 생성/PR 생성 시 이슈 상태 자동 전이 기능 구현 close #33

### DIFF
--- a/.github/workflows/on-branch-create.yml
+++ b/.github/workflows/on-branch-create.yml
@@ -1,6 +1,3 @@
----
-# ✅ on-branch-create.yml (브랜치 생성 시 In Progress 전이)
-
 name: On Branch Created
 
 on:
@@ -67,7 +64,7 @@ jobs:
             exit 0
           fi
 
-          # Status 필드 및 In Progress 옵션 ID 조회
+          # Status 필드 및 In Progress 옵션 ID 조회 (Fragment 사용)
           STATUS_FIELD_ID=$(gh api graphql -f query="query { node(id: \"$PROJECT_ID\") { ... on ProjectV2 { fields(first: 20) { nodes { id name } } } } }" --jq '.data.node.fields.nodes[] | select(.name=="Status") | .id')
           IN_PROGRESS_OPTION_ID=$(gh api graphql -f query="query { node(id: \"$PROJECT_ID\") { ... on ProjectV2 { field(id: \"$STATUS_FIELD_ID\") { ... on ProjectV2SingleSelectField { options { id name } } } } } }" --jq '.data.node.field.options[] | select(.name=="In Progress") | .id')
 

--- a/.github/workflows/on-branch-create.yml
+++ b/.github/workflows/on-branch-create.yml
@@ -1,3 +1,6 @@
+---
+# ✅ on-branch-create.yml (브랜치 생성 시 In Progress 전이)
+
 name: On Branch Created
 
 on:
@@ -29,35 +32,19 @@ jobs:
           OWNER=TEAM-JJINS
           PROJECT_NUMBER=1
 
-          # 1. 이슈 존재 여부 확인
-          ISSUE_ID=$(gh api graphql -f query='
-            query($owner: String!, $repo: String!, $issue: Int!) {
-              repository(owner: $owner, name: $repo) {
-                issue(number: $issue) {
-                  id
-                }
-              }
-            }' -f owner="$OWNER" -f repo="$REPO" -F issue=$ISSUE_NUMBER --jq '.data.repository.issue.id')
-
+          # 이슈 ID 조회
+          ISSUE_ID=$(gh api graphql -f query="query { repository(owner: \"$OWNER\", name: \"$REPO\") { issue(number: $ISSUE_NUMBER) { id } } }" --jq '.data.repository.issue.id')
           if [ -z "$ISSUE_ID" ]; then
             echo "⚠️ 이슈 #$ISSUE_NUMBER를 찾을 수 없습니다. 상태 전이 생략."
             exit 0
           fi
 
-          # 2. 프로젝트 ID 조회
-          PROJECT_ID=$(gh api graphql -f query='
-            query {
-              organization(login: "TEAM-JJINS") {
-                projectV2(number: 1) {
-                  id
-                }
-              }
-            }' --jq '.data.organization.projectV2.id')
+          # 프로젝트 ID 조회
+          PROJECT_ID=$(gh api graphql -f query="query { organization(login: \"$OWNER\") { projectV2(number: $PROJECT_NUMBER) { id } } }" --jq '.data.organization.projectV2.id')
 
-          # 3. itemId 페이지네이션으로 조회 (이미 포함된 경우만)
+          # itemId 조회 (페이지네이션)
           ITEM_ID=""
-          CURSOR="null"
-
+          CURSOR=null
           while true; do
             if [ "$CURSOR" = "null" ]; then
               QUERY_ARG='first: 100'
@@ -65,98 +52,25 @@ jobs:
               QUERY_ARG="first: 100, after: \"$CURSOR\""
             fi
 
-            RESPONSE=$(gh api graphql -f query="
-              query {
-                organization(login: \\\"TEAM-JJINS\\\") {
-                  projectV2(number: 1) {
-                    items($QUERY_ARG) {
-                      pageInfo {
-                        endCursor
-                        hasNextPage
-                      }
-                      nodes {
-                        id
-                        content {
-                          ... on Issue {
-                            number
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            ")
+            RESPONSE=$(gh api graphql -f query="query { organization(login: \"$OWNER\") { projectV2(number: $PROJECT_NUMBER) { items($QUERY_ARG) { pageInfo { endCursor hasNextPage } nodes { id content { ... on Issue { number } } } } } } }")
 
-            ITEM_ID=$(echo "$RESPONSE" | jq -r --argjson issue "$ISSUE_NUMBER" '
-              .data.organization.projectV2.items.nodes[]
-              | select(.content.number == $issue)
-              | .id
-            ')
-
-            if [ -n "$ITEM_ID" ] && [ "$ITEM_ID" != "null" ]; then
-              echo "✅ 프로젝트 내 이슈 항목 ID 발견: $ITEM_ID"
-              break
-            fi
+            ITEM_ID=$(echo "$RESPONSE" | jq -r --argjson issue "$ISSUE_NUMBER" '.data.organization.projectV2.items.nodes[] | select(.content.number == $issue) | .id')
+            if [ -n "$ITEM_ID" ] && [ "$ITEM_ID" != "null" ]; then break; fi
 
             HAS_NEXT=$(echo "$RESPONSE" | jq -r '.data.organization.projectV2.items.pageInfo.hasNextPage')
-            if [ "$HAS_NEXT" != "true" ]; then
-              break
-            fi
-
+            if [ "$HAS_NEXT" != "true" ]; then break; fi
             CURSOR=$(echo "$RESPONSE" | jq -r '.data.organization.projectV2.items.pageInfo.endCursor')
           done
 
           if [ -z "$ITEM_ID" ]; then
-            echo "⚠️ 이슈는 존재하지만 프로젝트에 포함되어 있지 않아 상태 전이를 생략합니다."
+            echo "⚠️ 프로젝트에 포함되지 않은 이슈입니다. 상태 전이 생략."
             exit 0
           fi
 
-          # 4. Status 필드 ID 조회
-          STATUS_FIELD_ID=$(gh api graphql -f query='
-            query {
-              node(id: "'$PROJECT_ID'") {
-                ... on ProjectV2 {
-                  fields(first: 20) {
-                    nodes {
-                      id
-                      name
-                    }
-                  }
-                }
-              }
-            }' --jq '.data.node.fields.nodes[] | select(.name=="Status") | .id')
+          # Status 필드 및 In Progress 옵션 ID 조회
+          STATUS_FIELD_ID=$(gh api graphql -f query="query { node(id: \"$PROJECT_ID\") { ... on ProjectV2 { fields(first: 20) { nodes { id name } } } } }" --jq '.data.node.fields.nodes[] | select(.name=="Status") | .id')
+          IN_PROGRESS_OPTION_ID=$(gh api graphql -f query="query { node(id: \"$PROJECT_ID\") { ... on ProjectV2 { field(id: \"$STATUS_FIELD_ID\") { ... on ProjectV2SingleSelectField { options { id name } } } } } }" --jq '.data.node.field.options[] | select(.name=="In Progress") | .id')
 
-          # 5. 'In Progress' 옵션 ID 조회
-          IN_PROGRESS_OPTION_ID=$(gh api graphql -f query='
-            query {
-              node(id: "'$PROJECT_ID'") {
-                ... on ProjectV2 {
-                  field(id: "'$STATUS_FIELD_ID'") {
-                    ... on ProjectV2SingleSelectField {
-                      options {
-                        id
-                        name
-                      }
-                    }
-                  }
-                }
-              }
-            }' --jq '.data.node.field.options[] | select(.name=="In Progress") | .id')
-
-          # 6. 상태 필드 값 변경 (In Progress로)
-          gh api graphql -f query='
-            mutation {
-              updateProjectV2ItemFieldValue(input: {
-                projectId: "'$PROJECT_ID'",
-                itemId: "'$ITEM_ID'",
-                fieldId: "'$STATUS_FIELD_ID'",
-                value: { singleSelectOptionId: "'$IN_PROGRESS_OPTION_ID'" }
-              }) {
-                projectV2Item {
-                  id
-                }
-              }
-            }'
-
-          echo "✅ 이슈 #$ISSUE_NUMBER의 상태가 'In Progress'로 전이 완료되었습니다."
+          # 상태 전이 실행
+          gh api graphql -f query="mutation { updateProjectV2ItemFieldValue(input: { projectId: \"$PROJECT_ID\", itemId: \"$ITEM_ID\", fieldId: \"$STATUS_FIELD_ID\", value: { singleSelectOptionId: \"$IN_PROGRESS_OPTION_ID\" } }) { projectV2Item { id } } }"
+          echo "✅ 상태 전이 완료: In Progress"

--- a/.github/workflows/on-branch-create.yml
+++ b/.github/workflows/on-branch-create.yml
@@ -1,0 +1,109 @@
+name: On Branch Created
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: '브랜치명 (예: feature#123/login-api)'
+        required: true
+      issue:
+        description: '연결된 이슈 번호 (예: 123)'
+        required: true
+
+jobs:
+  move-issue-to-in-progress:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: ✅ 입력값 출력
+        run: |
+          echo "📦 브랜치명: ${{ github.event.inputs.branch }}"
+          echo "🔗 이슈 번호: #${{ github.event.inputs.issue }}"
+
+      - name: 🔄 GitHub Projects 상태를 'In Progress'로 변경
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          ISSUE_NUMBER=${{ github.event.inputs.issue }}
+          REPO=cs-algo
+          OWNER=TEAM-JJINS
+          PROJECT_NUMBER=1
+
+          # 이슈 ID 조회
+          ISSUE_ID=$(gh api graphql -f query='
+            query($owner: String!, $repo: String!, $issue: Int!) {
+              repository(owner: $owner, name: $repo) {
+                issue(number: $issue) {
+                  id
+                }
+              }
+            }' -f owner="$OWNER" -f repo="$REPO" -F issue=$ISSUE_NUMBER --jq '.data.repository.issue.id')
+
+          # 프로젝트 ID 조회
+          PROJECT_ID=$(gh api graphql -f query='
+            query {
+              organization(login: "TEAM-JJINS") {
+                projectV2(number: 1) {
+                  id
+                }
+              }
+            }' --jq '.data.organization.projectV2.id')
+
+          # 이슈를 프로젝트에 추가
+          ITEM_ID=$(gh api graphql -f query='
+            mutation($projectId: ID!, $contentId: ID!) {
+              addProjectV2ItemById(input: {projectId: $projectId, contentId: $contentId}) {
+                item {
+                  id
+                }
+              }
+            }' -f projectId="$PROJECT_ID" -f contentId="$ISSUE_ID" --jq '.data.addProjectV2ItemById.item.id')
+
+          # Status 필드 ID 조회
+          STATUS_FIELD_ID=$(gh api graphql -f query='
+            query {
+              node(id: "'$PROJECT_ID'") {
+                ... on ProjectV2 {
+                  fields(first: 20) {
+                    nodes {
+                      id
+                      name
+                    }
+                  }
+                }
+              }
+            }' --jq '.data.node.fields.nodes[] | select(.name=="Status") | .id')
+
+          # In Progress 옵션 ID 조회
+          IN_PROGRESS_OPTION_ID=$(gh api graphql -f query='
+            query {
+              node(id: "'$PROJECT_ID'") {
+                ... on ProjectV2 {
+                  field(id: "'$STATUS_FIELD_ID'") {
+                    ... on ProjectV2SingleSelectField {
+                      options {
+                        id
+                        name
+                      }
+                    }
+                  }
+                }
+              }
+            }' --jq '.data.node.field.options[] | select(.name=="In Progress") | .id')
+
+          # 이슈의 Status 값을 In Progress로 변경
+          gh api graphql -f query='
+            mutation {
+              updateProjectV2ItemFieldValue(input: {
+                projectId: "'$PROJECT_ID'",
+                itemId: "'$ITEM_ID'",
+                fieldId: "'$STATUS_FIELD_ID'",
+                value: { singleSelectOptionId: "'$IN_PROGRESS_OPTION_ID'" }
+              }) {
+                projectV2Item {
+                  id
+                }
+              }
+            }'
+
+          echo "✅ 이슈 #$ISSUE_NUMBER의 상태가 'In Progress'로 전이 완료되었습니다."

--- a/.github/workflows/on-branch-create.yml
+++ b/.github/workflows/on-branch-create.yml
@@ -29,31 +29,29 @@ jobs:
           OWNER=TEAM-JJINS
           PROJECT_NUMBER=1
 
-          # 이슈 ID 조회
           ISSUE_ID=$(gh api graphql -f query="query { repository(owner: \"$OWNER\", name: \"$REPO\") { issue(number: $ISSUE_NUMBER) { id } } }" --jq '.data.repository.issue.id')
           if [ -z "$ISSUE_ID" ]; then
             echo "⚠️ 이슈 #$ISSUE_NUMBER를 찾을 수 없습니다. 상태 전이 생략."
             exit 0
           fi
 
-          # 프로젝트 ID 조회
           PROJECT_ID=$(gh api graphql -f query="query { organization(login: \"$OWNER\") { projectV2(number: $PROJECT_NUMBER) { id } } }" --jq '.data.organization.projectV2.id')
 
-          # itemId 조회 (페이지네이션)
+          PROJECT_FIELDS=$(gh api graphql -f query="query { node(id: \"$PROJECT_ID\") { ... on ProjectV2 { fields(first: 20) { nodes { ... on ProjectV2SingleSelectField { id name options { id name } } } } } } }")
+
+          STATUS_FIELD_ID=$(echo "$PROJECT_FIELDS" | jq -r '.data.node.fields.nodes[] | select(.name=="Status") | .id')
+          echo "📌 STATUS_FIELD_ID: $STATUS_FIELD_ID"
+
+          IN_PROGRESS_OPTION_ID=$(echo "$PROJECT_FIELDS" | jq -r '.data.node.fields.nodes[] | select(.name=="Status") | .options[] | select(.name=="In Progress") | .id')
+          echo "📌 IN_PROGRESS_OPTION_ID: $IN_PROGRESS_OPTION_ID"
+
           ITEM_ID=""
           CURSOR=null
           while true; do
-            if [ "$CURSOR" = "null" ]; then
-              QUERY_ARG='first: 100'
-            else
-              QUERY_ARG="first: 100, after: \"$CURSOR\""
-            fi
-
+            if [ "$CURSOR" = "null" ]; then QUERY_ARG='first: 100'; else QUERY_ARG="first: 100, after: \"$CURSOR\""; fi
             RESPONSE=$(gh api graphql -f query="query { organization(login: \"$OWNER\") { projectV2(number: $PROJECT_NUMBER) { items($QUERY_ARG) { pageInfo { endCursor hasNextPage } nodes { id content { ... on Issue { number } } } } } } }")
-
             ITEM_ID=$(echo "$RESPONSE" | jq -r --argjson issue "$ISSUE_NUMBER" '.data.organization.projectV2.items.nodes[] | select(.content.number == $issue) | .id')
             if [ -n "$ITEM_ID" ] && [ "$ITEM_ID" != "null" ]; then break; fi
-
             HAS_NEXT=$(echo "$RESPONSE" | jq -r '.data.organization.projectV2.items.pageInfo.hasNextPage')
             if [ "$HAS_NEXT" != "true" ]; then break; fi
             CURSOR=$(echo "$RESPONSE" | jq -r '.data.organization.projectV2.items.pageInfo.endCursor')
@@ -64,11 +62,15 @@ jobs:
             exit 0
           fi
 
-          # Status 필드 및 In Progress 옵션 ID 조회 (Fragment 사용)
-          STATUS_FIELD_ID=$(gh api graphql -f query="query { node(id: \"$PROJECT_ID\") { ... on ProjectV2 { fields(first: 20) { nodes { id name } } } } }" --jq '.data.node.fields.nodes[] | select(.name=="Status") | .id')
+          gh api graphql -f query="mutation {
+            updateProjectV2ItemFieldValue(input: {
+              projectId: \"$PROJECT_ID\",
+              itemId: \"$ITEM_ID\",
+              fieldId: \"$STATUS_FIELD_ID\",
+              value: { singleSelectOptionId: \"$IN_PROGRESS_OPTION_ID\" }
+            }) {
+              projectV2Item { id }
+            }
+          }"
 
-          IN_PROGRESS_OPTION_ID=$(gh api graphql -f query="query { node(id: \"$STATUS_FIELD_ID\") { ... on ProjectV2SingleSelectField { options { id name } } } }" --jq '.data.node.options[] | select(.name=="In Progress") | .id')
-
-          # 상태 전이 실행
-          gh api graphql -f query="mutation { updateProjectV2ItemFieldValue(input: { projectId: \"$PROJECT_ID\", itemId: \"$ITEM_ID\", fieldId: \"$STATUS_FIELD_ID\", value: { singleSelectOptionId: \"$IN_PROGRESS_OPTION_ID\" } }) { projectV2Item { id } } }"
           echo "✅ 상태 전이 완료: In Progress"

--- a/.github/workflows/on-branch-create.yml
+++ b/.github/workflows/on-branch-create.yml
@@ -66,7 +66,7 @@ jobs:
 
           # Status 필드 및 In Progress 옵션 ID 조회 (Fragment 사용)
           STATUS_FIELD_ID=$(gh api graphql -f query="query { node(id: \"$PROJECT_ID\") { ... on ProjectV2 { fields(first: 20) { nodes { id name } } } } }" --jq '.data.node.fields.nodes[] | select(.name=="Status") | .id')
-          IN_PROGRESS_OPTION_ID=$(gh api graphql -f query="query { node(id: \"$PROJECT_ID\") { ... on ProjectV2 { field(id: \"$STATUS_FIELD_ID\") { ... on ProjectV2SingleSelectField { options { id name } } } } } }" --jq '.data.node.field.options[] | select(.name=="In Progress") | .id')
+          IN_PROGRESS_OPTION_ID=$(gh api graphql -f query="query { node(id: \\\"$STATUS_FIELD_ID\\\") { ... on ProjectV2SingleSelectField { options { id name } } } }" --jq '.data.node.options[] | select(.name=="In Progress") | .id')
 
           # 상태 전이 실행
           gh api graphql -f query="mutation { updateProjectV2ItemFieldValue(input: { projectId: \"$PROJECT_ID\", itemId: \"$ITEM_ID\", fieldId: \"$STATUS_FIELD_ID\", value: { singleSelectOptionId: \"$IN_PROGRESS_OPTION_ID\" } }) { projectV2Item { id } } }"

--- a/.github/workflows/on-branch-create.yml
+++ b/.github/workflows/on-branch-create.yml
@@ -20,16 +20,16 @@ jobs:
           echo "📦 브랜치명: ${{ github.event.inputs.branch }}"
           echo "🔗 이슈 번호: #${{ github.event.inputs.issue }}"
 
-      - name: 🔄 GitHub Projects 상태를 'In Progress'로 변경
+      - name: 🔄 GitHub Projects 상태를 In Progress로 변경
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+          GH_TOKEN: ${{ secrets.GH_PAT }}
         run: |
           ISSUE_NUMBER=${{ github.event.inputs.issue }}
           REPO=cs-algo
           OWNER=TEAM-JJINS
           PROJECT_NUMBER=1
 
-          # 이슈 ID 조회
+          # 1. 이슈 존재 여부 확인
           ISSUE_ID=$(gh api graphql -f query='
             query($owner: String!, $repo: String!, $issue: Int!) {
               repository(owner: $owner, name: $repo) {
@@ -39,7 +39,12 @@ jobs:
               }
             }' -f owner="$OWNER" -f repo="$REPO" -F issue=$ISSUE_NUMBER --jq '.data.repository.issue.id')
 
-          # 프로젝트 ID 조회
+          if [ -z "$ISSUE_ID" ]; then
+            echo "⚠️ 이슈 #$ISSUE_NUMBER를 찾을 수 없습니다. 상태 전이 생략."
+            exit 0
+          fi
+
+          # 2. 프로젝트 ID 조회
           PROJECT_ID=$(gh api graphql -f query='
             query {
               organization(login: "TEAM-JJINS") {
@@ -49,17 +54,65 @@ jobs:
               }
             }' --jq '.data.organization.projectV2.id')
 
-          # 이슈를 프로젝트에 추가
-          ITEM_ID=$(gh api graphql -f query='
-            mutation($projectId: ID!, $contentId: ID!) {
-              addProjectV2ItemById(input: {projectId: $projectId, contentId: $contentId}) {
-                item {
-                  id
+          # 3. itemId 페이지네이션으로 조회 (이미 포함된 경우만)
+          ITEM_ID=""
+          CURSOR="null"
+
+          while true; do
+            if [ "$CURSOR" = "null" ]; then
+              QUERY_ARG='first: 100'
+            else
+              QUERY_ARG="first: 100, after: \"$CURSOR\""
+            fi
+
+            RESPONSE=$(gh api graphql -f query="
+              query {
+                organization(login: \\\"TEAM-JJINS\\\") {
+                  projectV2(number: 1) {
+                    items($QUERY_ARG) {
+                      pageInfo {
+                        endCursor
+                        hasNextPage
+                      }
+                      nodes {
+                        id
+                        content {
+                          ... on Issue {
+                            number
+                          }
+                        }
+                      }
+                    }
+                  }
                 }
               }
-            }' -f projectId="$PROJECT_ID" -f contentId="$ISSUE_ID" --jq '.data.addProjectV2ItemById.item.id')
+            ")
 
-          # Status 필드 ID 조회
+            ITEM_ID=$(echo "$RESPONSE" | jq -r --argjson issue "$ISSUE_NUMBER" '
+              .data.organization.projectV2.items.nodes[]
+              | select(.content.number == $issue)
+              | .id
+            ')
+
+            if [ -n "$ITEM_ID" ] && [ "$ITEM_ID" != "null" ]; then
+              echo "✅ 프로젝트 내 이슈 항목 ID 발견: $ITEM_ID"
+              break
+            fi
+
+            HAS_NEXT=$(echo "$RESPONSE" | jq -r '.data.organization.projectV2.items.pageInfo.hasNextPage')
+            if [ "$HAS_NEXT" != "true" ]; then
+              break
+            fi
+
+            CURSOR=$(echo "$RESPONSE" | jq -r '.data.organization.projectV2.items.pageInfo.endCursor')
+          done
+
+          if [ -z "$ITEM_ID" ]; then
+            echo "⚠️ 이슈는 존재하지만 프로젝트에 포함되어 있지 않아 상태 전이를 생략합니다."
+            exit 0
+          fi
+
+          # 4. Status 필드 ID 조회
           STATUS_FIELD_ID=$(gh api graphql -f query='
             query {
               node(id: "'$PROJECT_ID'") {
@@ -74,7 +127,7 @@ jobs:
               }
             }' --jq '.data.node.fields.nodes[] | select(.name=="Status") | .id')
 
-          # In Progress 옵션 ID 조회
+          # 5. 'In Progress' 옵션 ID 조회
           IN_PROGRESS_OPTION_ID=$(gh api graphql -f query='
             query {
               node(id: "'$PROJECT_ID'") {
@@ -91,7 +144,7 @@ jobs:
               }
             }' --jq '.data.node.field.options[] | select(.name=="In Progress") | .id')
 
-          # 이슈의 Status 값을 In Progress로 변경
+          # 6. 상태 필드 값 변경 (In Progress로)
           gh api graphql -f query='
             mutation {
               updateProjectV2ItemFieldValue(input: {

--- a/.github/workflows/on-branch-create.yml
+++ b/.github/workflows/on-branch-create.yml
@@ -66,7 +66,8 @@ jobs:
 
           # Status 필드 및 In Progress 옵션 ID 조회 (Fragment 사용)
           STATUS_FIELD_ID=$(gh api graphql -f query="query { node(id: \"$PROJECT_ID\") { ... on ProjectV2 { fields(first: 20) { nodes { id name } } } } }" --jq '.data.node.fields.nodes[] | select(.name=="Status") | .id')
-          IN_PROGRESS_OPTION_ID=$(gh api graphql -f query="query { node(id: \\\"$STATUS_FIELD_ID\\\") { ... on ProjectV2SingleSelectField { options { id name } } } }" --jq '.data.node.options[] | select(.name=="In Progress") | .id')
+
+          IN_PROGRESS_OPTION_ID=$(gh api graphql -f query="query { node(id: \"$STATUS_FIELD_ID\") { ... on ProjectV2SingleSelectField { options { id name } } } }" --jq '.data.node.options[] | select(.name=="In Progress") | .id')
 
           # 상태 전이 실행
           gh api graphql -f query="mutation { updateProjectV2ItemFieldValue(input: { projectId: \"$PROJECT_ID\", itemId: \"$ITEM_ID\", fieldId: \"$STATUS_FIELD_ID\", value: { singleSelectOptionId: \"$IN_PROGRESS_OPTION_ID\" } }) { projectV2Item { id } } }"

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -62,7 +62,7 @@ jobs:
           STATUS_FIELD_ID=$(gh api graphql -f query="query { node(id: \"$PROJECT_ID\") { ... on ProjectV2 { fields(first: 20) { nodes { id name } } } } }" --jq '.data.node.fields.nodes[] | select(.name=="Status") | .id')
           echo "📌 STATUS_FIELD_ID: $STATUS_FIELD_ID"
           
-          IN_REVIEW_OPTION_ID=$(gh api graphql -f query="query { node(id: \\\"$STATUS_FIELD_ID\\\") { ... on ProjectV2SingleSelectField { options { id name } } } }" --jq '.data.node.options[] | select(.name=="In Review") | .id')
+          IN_REVIEW_OPTION_ID=$(gh api graphql -f query="query { node(id: \"$STATUS_FIELD_ID\") { ... on ProjectV2SingleSelectField { options { id name } } } }" --jq '.data.node.options[] | select(.name=="In Review") | .id')
           echo "📌 IN_REVIEW_OPTION_ID: $IN_REVIEW_OPTION_ID"
           
           gh api graphql -f query="mutation { updateProjectV2ItemFieldValue(input: { projectId: \"$PROJECT_ID\", itemId: \"$ITEM_ID\", fieldId: \"$STATUS_FIELD_ID\", value: { singleSelectOptionId: \"$IN_REVIEW_OPTION_ID\" } }) { projectV2Item { id } } }"

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -60,7 +60,10 @@ jobs:
           fi
 
           STATUS_FIELD_ID=$(gh api graphql -f query="query { node(id: \"$PROJECT_ID\") { ... on ProjectV2 { fields(first: 20) { nodes { id name } } } } }" --jq '.data.node.fields.nodes[] | select(.name=="Status") | .id')
+          echo "📌 STATUS_FIELD_ID: $STATUS_FIELD_ID"
+          
           IN_REVIEW_OPTION_ID=$(gh api graphql -f query="query { node(id: \"$PROJECT_ID\") { ... on ProjectV2 { field(id: \"$STATUS_FIELD_ID\") { ... on ProjectV2SingleSelectField { options { id name } } } } } }" --jq '.data.node.field.options[] | select(.name=="In Review") | .id')
-
+          echo "📌 IN_REVIEW_OPTION_ID: $IN_REVIEW_OPTION_ID"
+          
           gh api graphql -f query="mutation { updateProjectV2ItemFieldValue(input: { projectId: \"$PROJECT_ID\", itemId: \"$ITEM_ID\", fieldId: \"$STATUS_FIELD_ID\", value: { singleSelectOptionId: \"$IN_REVIEW_OPTION_ID\" } }) { projectV2Item { id } } }"
           echo "✅ 상태 전이 완료: In Review"

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -2,7 +2,7 @@ name: On Pull Request Created
 
 on:
   pull_request:
-    types: [ opened ]
+    types: [ opened, reopened, synchronize ]
 
 jobs:
   move-issue-to-in-review:

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -62,7 +62,7 @@ jobs:
           STATUS_FIELD_ID=$(gh api graphql -f query="query { node(id: \"$PROJECT_ID\") { ... on ProjectV2 { fields(first: 20) { nodes { id name } } } } }" --jq '.data.node.fields.nodes[] | select(.name=="Status") | .id')
           echo "📌 STATUS_FIELD_ID: $STATUS_FIELD_ID"
           
-          IN_REVIEW_OPTION_ID=$(gh api graphql -f query="query { node(id: \"$PROJECT_ID\") { ... on ProjectV2 { field(id: \"$STATUS_FIELD_ID\") { ... on ProjectV2SingleSelectField { options { id name } } } } } }" --jq '.data.node.field.options[] | select(.name=="In Review") | .id')
+          IN_REVIEW_OPTION_ID=$(gh api graphql -f query="query { node(id: \\\"$STATUS_FIELD_ID\\\") { ... on ProjectV2SingleSelectField { options { id name } } } }" --jq '.data.node.options[] | select(.name=="In Review") | .id')
           echo "📌 IN_REVIEW_OPTION_ID: $IN_REVIEW_OPTION_ID"
           
           gh api graphql -f query="mutation { updateProjectV2ItemFieldValue(input: { projectId: \"$PROJECT_ID\", itemId: \"$ITEM_ID\", fieldId: \"$STATUS_FIELD_ID\", value: { singleSelectOptionId: \"$IN_REVIEW_OPTION_ID\" } }) { projectV2Item { id } } }"

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -62,24 +62,58 @@ jobs:
               }
             }' --jq '.data.organization.projectV2.id')
 
-          # 3. itemId 조회 (이미 포함된 경우만)
-          ITEM_ID=$(gh api graphql -f query='
-            query {
-              organization(login: "TEAM-JJINS") {
-                projectV2(number: 1) {
-                  items(first: 100, query: "issue:'$ISSUE_NUMBER'") {
-                    nodes {
-                      content {
-                        ... on Issue {
-                          number
+          # 3. itemId 페이지네이션 기반 조회
+          ITEM_ID=""
+          CURSOR="null"
+
+          while true; do
+            if [ "$CURSOR" = "null" ]; then
+              QUERY_ARG='first: 100'
+            else
+              QUERY_ARG="first: 100, after: \"$CURSOR\""
+            fi
+
+            RESPONSE=$(gh api graphql -f query="
+              query {
+                organization(login: \\\"TEAM-JJINS\\\") {
+                  projectV2(number: 1) {
+                    items($QUERY_ARG) {
+                      pageInfo {
+                        endCursor
+                        hasNextPage
+                      }
+                      nodes {
+                        id
+                        content {
+                          ... on Issue {
+                            number
+                          }
                         }
                       }
-                      id
                     }
                   }
                 }
               }
-            }' --jq ".data.organization.projectV2.items.nodes[] | select(.content.number==$ISSUE_NUMBER) | .id")
+            ")
+
+            ITEM_ID=$(echo "$RESPONSE" | jq -r --argjson issue "$ISSUE_NUMBER" '
+              .data.organization.projectV2.items.nodes[]
+              | select(.content.number == $issue)
+              | .id
+            ')
+
+            if [ -n "$ITEM_ID" ] && [ "$ITEM_ID" != "null" ]; then
+              echo "✅ 프로젝트 내 이슈 항목 ID 발견: $ITEM_ID"
+              break
+            fi
+
+            HAS_NEXT=$(echo "$RESPONSE" | jq -r '.data.organization.projectV2.items.pageInfo.hasNextPage')
+            if [ "$HAS_NEXT" != "true" ]; then
+              break
+            fi
+
+            CURSOR=$(echo "$RESPONSE" | jq -r '.data.organization.projectV2.items.pageInfo.endCursor')
+          done
 
           if [ -z "$ITEM_ID" ]; then
             echo "⚠️ 이슈는 존재하지만 프로젝트에 포함되어 있지 않아 상태 전이를 생략합니다."

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -19,13 +19,10 @@ jobs:
         run: |
           BRANCH_NAME="${{ github.event.pull_request.head.ref }}"
           ISSUE_NUMBER=$(echo "$BRANCH_NAME" | grep -oE '#[0-9]+' | tr -d '#')
-
           if [ -z "$ISSUE_NUMBER" ]; then
-            echo "❌ 브랜치명에서 이슈 번호를 찾을 수 없습니다. 형식: type#123/description"
+            echo "❌ 브랜치명에서 이슈 번호 추출 실패."
             exit 1
           fi
-
-          echo "🔗 이슈 번호: $ISSUE_NUMBER"
           echo "issue_number=$ISSUE_NUMBER" >> $GITHUB_OUTPUT
 
       - name: 🔄 GitHub Projects 상태를 In Review로 변경
@@ -37,134 +34,33 @@ jobs:
           OWNER=TEAM-JJINS
           PROJECT_NUMBER=1
 
-          # 1. 이슈 ID 조회
-          ISSUE_ID=$(gh api graphql -f query='
-            query($owner: String!, $repo: String!, $issue: Int!) {
-              repository(owner: $owner, name: $repo) {
-                issue(number: $issue) {
-                  id
-                }
-              }
-            }' -f owner="$OWNER" -f repo="$REPO" -F issue=$ISSUE_NUMBER --jq '.data.repository.issue.id')
-
+          ISSUE_ID=$(gh api graphql -f query="query { repository(owner: \"$OWNER\", name: \"$REPO\") { issue(number: $ISSUE_NUMBER) { id } } }" --jq '.data.repository.issue.id')
           if [ -z "$ISSUE_ID" ]; then
-            echo "⚠️ 이슈 #$ISSUE_NUMBER를 찾을 수 없습니다. 상태 전이 생략."
+            echo "⚠️ 이슈 없음. 상태 전이 생략."
             exit 0
           fi
 
-          # 2. 프로젝트 ID 조회
-          PROJECT_ID=$(gh api graphql -f query='
-            query {
-              organization(login: "TEAM-JJINS") {
-                projectV2(number: 1) {
-                  id
-                }
-              }
-            }' --jq '.data.organization.projectV2.id')
+          PROJECT_ID=$(gh api graphql -f query="query { organization(login: \"$OWNER\") { projectV2(number: $PROJECT_NUMBER) { id } } }" --jq '.data.organization.projectV2.id')
 
-          # 3. itemId 페이지네이션 기반 조회
           ITEM_ID=""
-          CURSOR="null"
-
+          CURSOR=null
           while true; do
-            if [ "$CURSOR" = "null" ]; then
-              QUERY_ARG='first: 100'
-            else
-              QUERY_ARG="first: 100, after: \"$CURSOR\""
-            fi
-
-            RESPONSE=$(gh api graphql -f query="
-              query {
-                organization(login: \\\"TEAM-JJINS\\\") {
-                  projectV2(number: 1) {
-                    items($QUERY_ARG) {
-                      pageInfo {
-                        endCursor
-                        hasNextPage
-                      }
-                      nodes {
-                        id
-                        content {
-                          ... on Issue {
-                            number
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            ")
-
-            ITEM_ID=$(echo "$RESPONSE" | jq -r --argjson issue "$ISSUE_NUMBER" '
-              .data.organization.projectV2.items.nodes[]
-              | select(.content.number == $issue)
-              | .id
-            ')
-
-            if [ -n "$ITEM_ID" ] && [ "$ITEM_ID" != "null" ]; then
-              echo "✅ 프로젝트 내 이슈 항목 ID 발견: $ITEM_ID"
-              break
-            fi
-
+            if [ "$CURSOR" = "null" ]; then QUERY_ARG='first: 100'; else QUERY_ARG="first: 100, after: \"$CURSOR\""; fi
+            RESPONSE=$(gh api graphql -f query="query { organization(login: \"$OWNER\") { projectV2(number: $PROJECT_NUMBER) { items($QUERY_ARG) { pageInfo { endCursor hasNextPage } nodes { id content { ... on Issue { number } } } } } } }")
+            ITEM_ID=$(echo "$RESPONSE" | jq -r --argjson issue "$ISSUE_NUMBER" '.data.organization.projectV2.items.nodes[] | select(.content.number == $issue) | .id')
+            if [ -n "$ITEM_ID" ] && [ "$ITEM_ID" != "null" ]; then break; fi
             HAS_NEXT=$(echo "$RESPONSE" | jq -r '.data.organization.projectV2.items.pageInfo.hasNextPage')
-            if [ "$HAS_NEXT" != "true" ]; then
-              break
-            fi
-
+            if [ "$HAS_NEXT" != "true" ]; then break; fi
             CURSOR=$(echo "$RESPONSE" | jq -r '.data.organization.projectV2.items.pageInfo.endCursor')
           done
 
           if [ -z "$ITEM_ID" ]; then
-            echo "⚠️ 이슈는 존재하지만 프로젝트에 포함되어 있지 않아 상태 전이를 생략합니다."
+            echo "⚠️ 프로젝트에 포함되지 않은 이슈입니다. 상태 전이 생략."
             exit 0
           fi
 
-          # 4. Status 필드 ID 조회
-          STATUS_FIELD_ID=$(gh api graphql -f query='
-            query {
-              node(id: "'$PROJECT_ID'") {
-                ... on ProjectV2 {
-                  fields(first: 20) {
-                    nodes {
-                      id
-                      name
-                    }
-                  }
-                }
-              }
-            }' --jq '.data.node.fields.nodes[] | select(.name=="Status") | .id')
+          STATUS_FIELD_ID=$(gh api graphql -f query="query { node(id: \"$PROJECT_ID\") { ... on ProjectV2 { fields(first: 20) { nodes { id name } } } } }" --jq '.data.node.fields.nodes[] | select(.name=="Status") | .id')
+          IN_REVIEW_OPTION_ID=$(gh api graphql -f query="query { node(id: \"$PROJECT_ID\") { ... on ProjectV2 { field(id: \"$STATUS_FIELD_ID\") { ... on ProjectV2SingleSelectField { options { id name } } } } } }" --jq '.data.node.field.options[] | select(.name=="In Review") | .id')
 
-          # 5. 'In Review' 옵션 ID 조회
-          IN_REVIEW_OPTION_ID=$(gh api graphql -f query='
-            query {
-              node(id: "'$PROJECT_ID'") {
-                ... on ProjectV2 {
-                  field(id: "'$STATUS_FIELD_ID'") {
-                    ... on ProjectV2SingleSelectField {
-                      options {
-                        id
-                        name
-                      }
-                    }
-                  }
-                }
-              }
-            }' --jq '.data.node.field.options[] | select(.name=="In Review") | .id')
-
-          # 6. 상태 필드 값 변경 (In Review로)
-          gh api graphql -f query='
-            mutation {
-              updateProjectV2ItemFieldValue(input: {
-                projectId: "'$PROJECT_ID'",
-                itemId: "'$ITEM_ID'",
-                fieldId: "'$STATUS_FIELD_ID'",
-                value: { singleSelectOptionId: "'$IN_REVIEW_OPTION_ID'" }
-              }) {
-                projectV2Item {
-                  id
-                }
-              }
-            }'
-
-          echo "✅ 이슈 #$ISSUE_NUMBER의 상태가 'In Review'로 전이 완료되었습니다."
+          gh api graphql -f query="mutation { updateProjectV2ItemFieldValue(input: { projectId: \"$PROJECT_ID\", itemId: \"$ITEM_ID\", fieldId: \"$STATUS_FIELD_ID\", value: { singleSelectOptionId: \"$IN_REVIEW_OPTION_ID\" } }) { projectV2Item { id } } }"
+          echo "✅ 상태 전이 완료: In Review"

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -34,13 +34,17 @@ jobs:
           OWNER=TEAM-JJINS
           PROJECT_NUMBER=1
 
+          echo "🔍 이슈 번호: $ISSUE_NUMBER"
+
           ISSUE_ID=$(gh api graphql -f query="query { repository(owner: \"$OWNER\", name: \"$REPO\") { issue(number: $ISSUE_NUMBER) { id } } }" --jq '.data.repository.issue.id')
+          echo "🆔 ISSUE_ID: $ISSUE_ID"
           if [ -z "$ISSUE_ID" ]; then
             echo "⚠️ 이슈 없음. 상태 전이 생략."
             exit 0
           fi
 
           PROJECT_ID=$(gh api graphql -f query="query { organization(login: \"$OWNER\") { projectV2(number: $PROJECT_NUMBER) { id } } }" --jq '.data.organization.projectV2.id')
+          echo "🆔 PROJECT_ID: $PROJECT_ID"
 
           ITEM_ID=""
           CURSOR=null
@@ -59,11 +63,59 @@ jobs:
             exit 0
           fi
 
-          STATUS_FIELD_ID=$(gh api graphql -f query="query { node(id: \"$PROJECT_ID\") { ... on ProjectV2 { fields(first: 20) { nodes { id name } } } } }" --jq '.data.node.fields.nodes[] | select(.name=="Status") | .id')
+          STATUS_FIELD_ID=$(gh api graphql -f query="query {
+            node(id: \"$PROJECT_ID\") {
+              ... on ProjectV2 {
+                fields(first: 20) {
+                  nodes {
+                    id
+                    name
+                  }
+                }
+              }
+            }
+          }" --jq '.data.node.fields.nodes[] | select(.name=="Status") | .id')
           echo "📌 STATUS_FIELD_ID: $STATUS_FIELD_ID"
-          
-          IN_REVIEW_OPTION_ID=$(gh api graphql -f query="query { node(id: \"$STATUS_FIELD_ID\") { ... on ProjectV2SingleSelectField { options { id name } } } }" --jq '.data.node.options[] | select(.name=="In Review") | .id')
+
+          # 필드의 실제 타입 확인
+          FIELD_TYPE=$(gh api graphql -f query="query {
+            node(id: \"$STATUS_FIELD_ID\") {
+              __typename
+            }
+          }" --jq '.data.node.__typename')
+          echo "📌 FIELD_TYPE: $FIELD_TYPE"
+
+          if [ "$FIELD_TYPE" != "ProjectV2SingleSelectField" ]; then
+            echo "❌ STATUS 필드 타입이 예상과 다릅니다: $FIELD_TYPE"
+            exit 1
+          fi
+
+          IN_REVIEW_OPTION_ID=$(gh api graphql -f query="query {
+            node(id: \"$STATUS_FIELD_ID\") {
+              ... on ProjectV2SingleSelectField {
+                options {
+                  id
+                  name
+                }
+              }
+            }
+          }" --jq '.data.node.options[] | select(.name=="In Review") | .id')
           echo "📌 IN_REVIEW_OPTION_ID: $IN_REVIEW_OPTION_ID"
-          
-          gh api graphql -f query="mutation { updateProjectV2ItemFieldValue(input: { projectId: \"$PROJECT_ID\", itemId: \"$ITEM_ID\", fieldId: \"$STATUS_FIELD_ID\", value: { singleSelectOptionId: \"$IN_REVIEW_OPTION_ID\" } }) { projectV2Item { id } } }"
-          echo "✅ 상태 전이 완료: In Review"
+
+          if [ -z "$IN_REVIEW_OPTION_ID" ]; then
+            echo "❌ In Review 옵션 ID를 찾을 수 없습니다."
+            exit 1
+          fi
+
+          gh api graphql -f query="mutation {
+            updateProjectV2ItemFieldValue(input: {
+              projectId: \"$PROJECT_ID\",
+              itemId: \"$ITEM_ID\",
+              fieldId: \"$STATUS_FIELD_ID\",
+              value: { singleSelectOptionId: \"$IN_REVIEW_OPTION_ID\" }
+            }) {
+              projectV2Item { id }
+            }
+          }"
+
+          echo "✅ 상태가 'In Review'로 변경되었습니다."

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -46,6 +46,14 @@ jobs:
           PROJECT_ID=$(gh api graphql -f query="query { organization(login: \"$OWNER\") { projectV2(number: $PROJECT_NUMBER) { id } } }" --jq '.data.organization.projectV2.id')
           echo "🆔 PROJECT_ID: $PROJECT_ID"
 
+          PROJECT_FIELDS=$(gh api graphql -f query="query { node(id: \"$PROJECT_ID\") { ... on ProjectV2 { fields(first: 20) { nodes { ... on ProjectV2SingleSelectField { id name options { id name } } } } } } }")
+
+          STATUS_FIELD_ID=$(echo "$PROJECT_FIELDS" | jq -r '.data.node.fields.nodes[] | select(.name=="Status") | .id')
+          echo "📌 STATUS_FIELD_ID: $STATUS_FIELD_ID"
+
+          IN_REVIEW_OPTION_ID=$(echo "$PROJECT_FIELDS" | jq -r '.data.node.fields.nodes[] | select(.name=="Status") | .options[] | select(.name=="In Review") | .id')
+          echo "📌 IN_REVIEW_OPTION_ID: $IN_REVIEW_OPTION_ID"
+
           ITEM_ID=""
           CURSOR=null
           while true; do
@@ -61,50 +69,6 @@ jobs:
           if [ -z "$ITEM_ID" ]; then
             echo "⚠️ 프로젝트에 포함되지 않은 이슈입니다. 상태 전이 생략."
             exit 0
-          fi
-
-          STATUS_FIELD_ID=$(gh api graphql -f query="query {
-            node(id: \"$PROJECT_ID\") {
-              ... on ProjectV2 {
-                fields(first: 20) {
-                  nodes {
-                    id
-                    name
-                  }
-                }
-              }
-            }
-          }" --jq '.data.node.fields.nodes[] | select(.name=="Status") | .id')
-          echo "📌 STATUS_FIELD_ID: $STATUS_FIELD_ID"
-
-          # 필드의 실제 타입 확인
-          FIELD_TYPE=$(gh api graphql -f query="query {
-            node(id: \"$STATUS_FIELD_ID\") {
-              __typename
-            }
-          }" --jq '.data.node.__typename')
-          echo "📌 FIELD_TYPE: $FIELD_TYPE"
-
-          if [ "$FIELD_TYPE" != "ProjectV2SingleSelectField" ]; then
-            echo "❌ STATUS 필드 타입이 예상과 다릅니다: $FIELD_TYPE"
-            exit 1
-          fi
-
-          IN_REVIEW_OPTION_ID=$(gh api graphql -f query="query {
-            node(id: \"$STATUS_FIELD_ID\") {
-              ... on ProjectV2SingleSelectField {
-                options {
-                  id
-                  name
-                }
-              }
-            }
-          }" --jq '.data.node.options[] | select(.name=="In Review") | .id')
-          echo "📌 IN_REVIEW_OPTION_ID: $IN_REVIEW_OPTION_ID"
-
-          if [ -z "$IN_REVIEW_OPTION_ID" ]; then
-            echo "❌ In Review 옵션 ID를 찾을 수 없습니다."
-            exit 1
           fi
 
           gh api graphql -f query="mutation {

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -1,0 +1,136 @@
+name: On Pull Request Created
+
+on:
+  pull_request:
+    types: [ opened ]
+
+jobs:
+  move-issue-to-in-review:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 🧪 PR 정보 출력
+        run: |
+          echo "📝 PR Title: ${{ github.event.pull_request.title }}"
+          echo "🌿 Source Branch: ${{ github.event.pull_request.head.ref }}"
+
+      - name: 🔍 브랜치명에서 이슈 번호 추출
+        id: extract
+        run: |
+          BRANCH_NAME="${{ github.event.pull_request.head.ref }}"
+          ISSUE_NUMBER=$(echo "$BRANCH_NAME" | grep -oE '#[0-9]+' | tr -d '#')
+
+          if [ -z "$ISSUE_NUMBER" ]; then
+            echo "❌ 브랜치명에서 이슈 번호를 찾을 수 없습니다. 형식: type#123/description"
+            exit 1
+          fi
+
+          echo "🔗 이슈 번호: $ISSUE_NUMBER"
+          echo "issue_number=$ISSUE_NUMBER" >> $GITHUB_OUTPUT
+
+      - name: 🔄 GitHub Projects 상태를 In Review로 변경
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          ISSUE_NUMBER=${{ steps.extract.outputs.issue_number }}
+          REPO=cs-algo
+          OWNER=TEAM-JJINS
+          PROJECT_NUMBER=1
+
+          # 1. 이슈 ID 조회
+          ISSUE_ID=$(gh api graphql -f query='
+            query($owner: String!, $repo: String!, $issue: Int!) {
+              repository(owner: $owner, name: $repo) {
+                issue(number: $issue) {
+                  id
+                }
+              }
+            }' -f owner="$OWNER" -f repo="$REPO" -F issue=$ISSUE_NUMBER --jq '.data.repository.issue.id')
+
+          if [ -z "$ISSUE_ID" ]; then
+            echo "⚠️ 이슈 #$ISSUE_NUMBER를 찾을 수 없습니다. 상태 전이 생략."
+            exit 0
+          fi
+
+          # 2. 프로젝트 ID 조회
+          PROJECT_ID=$(gh api graphql -f query='
+            query {
+              organization(login: "TEAM-JJINS") {
+                projectV2(number: 1) {
+                  id
+                }
+              }
+            }' --jq '.data.organization.projectV2.id')
+
+          # 3. itemId 조회 (이미 포함된 경우만)
+          ITEM_ID=$(gh api graphql -f query='
+            query {
+              organization(login: "TEAM-JJINS") {
+                projectV2(number: 1) {
+                  items(first: 100, query: "issue:'$ISSUE_NUMBER'") {
+                    nodes {
+                      content {
+                        ... on Issue {
+                          number
+                        }
+                      }
+                      id
+                    }
+                  }
+                }
+              }
+            }' --jq ".data.organization.projectV2.items.nodes[] | select(.content.number==$ISSUE_NUMBER) | .id")
+
+          if [ -z "$ITEM_ID" ]; then
+            echo "⚠️ 이슈는 존재하지만 프로젝트에 포함되어 있지 않아 상태 전이를 생략합니다."
+            exit 0
+          fi
+
+          # 4. Status 필드 ID 조회
+          STATUS_FIELD_ID=$(gh api graphql -f query='
+            query {
+              node(id: "'$PROJECT_ID'") {
+                ... on ProjectV2 {
+                  fields(first: 20) {
+                    nodes {
+                      id
+                      name
+                    }
+                  }
+                }
+              }
+            }' --jq '.data.node.fields.nodes[] | select(.name=="Status") | .id')
+
+          # 5. 'In Review' 옵션 ID 조회
+          IN_REVIEW_OPTION_ID=$(gh api graphql -f query='
+            query {
+              node(id: "'$PROJECT_ID'") {
+                ... on ProjectV2 {
+                  field(id: "'$STATUS_FIELD_ID'") {
+                    ... on ProjectV2SingleSelectField {
+                      options {
+                        id
+                        name
+                      }
+                    }
+                  }
+                }
+              }
+            }' --jq '.data.node.field.options[] | select(.name=="In Review") | .id')
+
+          # 6. 상태 필드 값 변경 (In Review로)
+          gh api graphql -f query='
+            mutation {
+              updateProjectV2ItemFieldValue(input: {
+                projectId: "'$PROJECT_ID'",
+                itemId: "'$ITEM_ID'",
+                fieldId: "'$STATUS_FIELD_ID'",
+                value: { singleSelectOptionId: "'$IN_REVIEW_OPTION_ID'" }
+              }) {
+                projectV2Item {
+                  id
+                }
+              }
+            }'
+
+          echo "✅ 이슈 #$ISSUE_NUMBER의 상태가 'In Review'로 전이 완료되었습니다."

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ out/
 
 ### Node.js ###
 node_modules/
+
+### Environment ###
+.env

--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -1,0 +1,50 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+echo ""
+echo "🔍 브랜치 이름 검사 및 GitHub Projects 상태 자동화 시작"
+
+BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
+
+# 예외 브랜치 (검사 제외)
+if echo "$BRANCH_NAME" | grep -Eq '^(main|develop|release.*)$'; then
+  echo "ℹ️ 시스템 브랜치('$BRANCH_NAME')는 네이밍 체크를 건너뜁니다."
+  exit 0
+fi
+
+# 브랜치 네이밍 규칙
+BRANCH_REGEX="^(feature|fix|hotfix|release|refactor|chore)#[0-9]+/[a-z0-9\-]+$"
+
+if ! echo "$BRANCH_NAME" | grep -Eq "$BRANCH_REGEX"; then
+  echo "⚠️ 브랜치 이름 규칙 위반: '$BRANCH_NAME'"
+  echo "   ✅ 예시: feature#123/login-api, fix#456/null-check, refactor#789/refine-logic"
+  exit 0  # checkout은 허용, 단 경고만 출력
+fi
+
+echo "✅ 브랜치 이름 규칙 통과: '$BRANCH_NAME'"
+
+# 이슈 번호 추출
+ISSUE_NUMBER=$(echo "$BRANCH_NAME" | grep -oE '#[0-9]+' | tr -d '#')
+
+# GitHub Actions 트리거
+echo ""
+echo "🔁 연결된 이슈(#${ISSUE_NUMBER})를 GitHub Projects에서 'In Progress'로 이동 중..."
+
+# curl 응답 본문과 HTTP 상태코드 추출
+response=$(curl -s -w "HTTP_STATUS:%{http_code}" \
+  -X POST \
+  -H "Accept: application/vnd.github+json" \
+  -H "Authorization: Bearer $GITHUB_PAT" \
+  https://api.github.com/repos/TEAM-JJINS/cs-algo/actions/workflows/on-branch-create.yml/dispatches \
+  -d "{\"ref\":\"main\", \"inputs\":{\"branch\":\"$BRANCH_NAME\",\"issue\":\"$ISSUE_NUMBER\"}}")
+
+# 응답 파싱
+body=$(echo "$response" | sed -e 's/HTTP_STATUS\:.*//g')
+status=$(echo "$response" | tr -d '\n' | sed -e 's/.*HTTP_STATUS://')
+
+if [ "$status" -eq 204 ]; then
+  echo "✅ 이슈 #${ISSUE_NUMBER}의 상태가 'In Progress'로 업데이트되었습니다. (GitHub Actions 연동)"
+else
+  echo "❌ GitHub Actions 트리거 실패 (HTTP $status)"
+  echo "📄 응답 내용: $body"
+fi

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,23 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
+
+# 예외 브랜치: main, develop, release*
+if echo "$BRANCH_NAME" | grep -Eq '^(main|develop|release.*)$'; then
+  echo "ℹ️ 시스템 브랜치('$BRANCH_NAME')는 네이밍 규칙 검사를 건너뜁니다."
+  exit 0
+fi
+
+# 브랜치명 규칙: type#123/description
+BRANCH_REGEX="^(feature|fix|hotfix|release|refactor)#[0-9]+/[a-z0-9\-]+$"
+
+if ! echo "$BRANCH_NAME" | grep -Eq "$BRANCH_REGEX"; then
+  echo "❌ 브랜치 이름 규칙 위반: '$BRANCH_NAME'"
+  echo "   ✅ 올바른 예시: feature#123/login-api, fix#456/null-check"
+  echo "🚫 푸시가 차단되었습니다. 브랜치명을 변경 후 다시 시도해 주세요."
+  exit 1
+fi
+
+echo "✅ 브랜치 이름 검증 통과: '$BRANCH_NAME'"
+exit 0

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -10,7 +10,7 @@ if echo "$BRANCH_NAME" | grep -Eq '^(main|develop|release.*)$'; then
 fi
 
 # 브랜치명 규칙: type#123/description
-BRANCH_REGEX="^(feature|fix|hotfix|release|refactor)#[0-9]+/[a-z0-9\-]+$"
+BRANCH_REGEX="^(feature|fix|hotfix|release|refactor|chore)#[0-9]+/[a-z0-9\-]+$"
 
 if ! echo "$BRANCH_NAME" | grep -Eq "$BRANCH_REGEX"; then
   echo "❌ 브랜치 이름 규칙 위반: '$BRANCH_NAME'"


### PR DESCRIPTION
<!-- (title: "[Type] Title close #IssueNumber") -->

## Motivation

<!-- 작성 배경 -->

- resolve #33 

## Problem Solving

<!-- 해결 방법 -->

- 브랜치 생성 시점에 `.husky/post-checkout` 훅을 통해 브랜치명을 검사하고, 유효한 경우 연결된 이슈를 GitHub Projects의 'In Progress' 상태로 자동 전이되도록 GitHub Actions 연동
- PR 생성 시점에 `.github/workflows/on-pull-request.yml` 워크플로우가 실행되어, 브랜치명에서 이슈 번호를 추출 후 해당 이슈를 'In Review' 상태로 전이
- 이슈가 존재하지 않거나, 프로젝트에 포함되어 있지 않으면 상태 전이를 생략하여 불필요한 에러 방지
- 브랜치명 규칙(`type#123/description`)에 맞지 않으면 푸시가 차단되도록 `.husky/pre-push` 훅 구성

## To Reviewer

<!-- 리뷰어에게 말하고 싶은 것, 유의 깊게 봐주었으면 하는 것, 의문점 등 -->

- `gh` CLI를 활용하여 GraphQL API로 프로젝트 상태를 조작하고 있으므로, 워크플로우 실행 환경에서 `GH_PAT` Secret이 반드시 등록되어 있어야 합니다. (제가 생성하여 추가하였습니다.)
- `.husky/post-checkout` 훅은 로컬에서 `.env` 파일을 읽어 `GH_PAT`를 환경 변수로 사용합니다. 다음과 같이 `.env` 파일을 루트에 생성해야 합니다.
	```env
	GH_PAT=ghp_yourPersonalAccessToken
	```
- .env 파일은 .gitignore에 포함되어 있어야 하며, Git에 커밋되지 않도록 주의해 주세요.
- 이슈가 GitHub Project에 미리 포함되어 있어야 상태 전이가 정상 동작합니다.
- 브랜치명에 `#이슈번호`가 누락되면 자동화가 동작하지 않도록 설계되어 있습니다. 브랜치명 규칙을 준수해 주세요!