### PR TITLE
[Fix] SoftDelete 미적용 이슈 해결

### DIFF
--- a/src/main/java/kr/co/csalgo/domain/common/entity/AuditableEntity.java
+++ b/src/main/java/kr/co/csalgo/domain/common/entity/AuditableEntity.java
@@ -1,8 +1,6 @@
 package kr.co.csalgo.domain.common.entity;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.EntityListeners;
-import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.*;
 import lombok.Getter;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
@@ -18,6 +16,9 @@ import java.time.LocalDateTime;
 @SQLRestriction("deleted_at IS NULL")
 @EntityListeners(AuditingEntityListener.class)
 public abstract class AuditableEntity extends IdentifiableEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
 
     @CreatedDate
     @Column(nullable = false)

--- a/src/main/java/kr/co/csalgo/domain/common/entity/AuditableEntity.java
+++ b/src/main/java/kr/co/csalgo/domain/common/entity/AuditableEntity.java
@@ -2,8 +2,6 @@ package kr.co.csalgo.domain.common.entity;
 
 import jakarta.persistence.*;
 import lombok.Getter;
-import org.hibernate.annotations.SQLDelete;
-import org.hibernate.annotations.SQLRestriction;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -12,8 +10,6 @@ import java.time.LocalDateTime;
 
 @Getter
 @MappedSuperclass
-@SQLDelete(sql = "UPDATE #{entityName} SET deleted_at = NOW() WHERE id = ?")
-@SQLRestriction("deleted_at IS NULL")
 @EntityListeners(AuditingEntityListener.class)
 public abstract class AuditableEntity extends IdentifiableEntity {
     @Id

--- a/src/main/java/kr/co/csalgo/domain/common/entity/AuditableEntity.java
+++ b/src/main/java/kr/co/csalgo/domain/common/entity/AuditableEntity.java
@@ -1,6 +1,8 @@
 package kr.co.csalgo.domain.common.entity;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
 import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
@@ -12,10 +14,6 @@ import java.time.LocalDateTime;
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
 public abstract class AuditableEntity extends IdentifiableEntity {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
-
     @CreatedDate
     @Column(nullable = false)
     private LocalDateTime createdAt;

--- a/src/main/java/kr/co/csalgo/domain/question/entity/Question.java
+++ b/src/main/java/kr/co/csalgo/domain/question/entity/Question.java
@@ -6,10 +6,14 @@ import kr.co.csalgo.domain.common.entity.AuditableEntity;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @NoArgsConstructor
 @Getter
+@SQLDelete(sql = "UPDATE question SET deleted_at = NOW() WHERE id = ?")
+@SQLRestriction("deleted_at IS NULL")
 public class Question extends AuditableEntity {
     @Column(nullable = false)
     private String title;

--- a/src/main/java/kr/co/csalgo/domain/question/entity/QuestionResponse.java
+++ b/src/main/java/kr/co/csalgo/domain/question/entity/QuestionResponse.java
@@ -6,10 +6,14 @@ import kr.co.csalgo.domain.user.entity.User;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @NoArgsConstructor
 @Getter
+@SQLDelete(sql = "UPDATE question_response SET deleted_at = NOW() WHERE id = ?")
+@SQLRestriction("deleted_at IS NULL")
 public class QuestionResponse extends AuditableEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/kr/co/csalgo/domain/question/entity/QuestionSendingHistory.java
+++ b/src/main/java/kr/co/csalgo/domain/question/entity/QuestionSendingHistory.java
@@ -9,10 +9,14 @@ import kr.co.csalgo.domain.user.entity.User;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @NoArgsConstructor
 @Getter
+@SQLDelete(sql = "UPDATE question_sending_history SET deleted_at = NOW() WHERE id = ?")
+@SQLRestriction("deleted_at IS NULL")
 public class QuestionSendingHistory extends AuditableEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "question_id", nullable = false)

--- a/src/main/java/kr/co/csalgo/domain/question/entity/ResponseFeedback.java
+++ b/src/main/java/kr/co/csalgo/domain/question/entity/ResponseFeedback.java
@@ -5,10 +5,14 @@ import kr.co.csalgo.domain.common.entity.AuditableEntity;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @NoArgsConstructor
 @Getter
+@SQLDelete(sql = "UPDATE response_feedback SET deleted_at = NOW() WHERE id = ?")
+@SQLRestriction("deleted_at IS NULL")
 public class ResponseFeedback extends AuditableEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "response_id", nullable = false)

--- a/src/main/java/kr/co/csalgo/domain/user/entity/User.java
+++ b/src/main/java/kr/co/csalgo/domain/user/entity/User.java
@@ -2,20 +2,21 @@ package kr.co.csalgo.domain.user.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EntityListeners;
 import kr.co.csalgo.domain.common.entity.AuditableEntity;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @NoArgsConstructor
 @Getter
-@EntityListeners(AuditingEntityListener.class)
+@SQLDelete(sql = "UPDATE user SET deleted_at = NOW() WHERE id = ?")
+@SQLRestriction("deleted_at IS NULL")
 public class User extends AuditableEntity {
-    
-    @Column(nullable = false, unique = true, length = 100)
+
+    @Column(nullable = false, length = 100)
     private String email;
 
 

--- a/src/main/java/kr/co/csalgo/domain/user/entity/User.java
+++ b/src/main/java/kr/co/csalgo/domain/user/entity/User.java
@@ -1,6 +1,8 @@
 package kr.co.csalgo.domain.user.entity;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import kr.co.csalgo.domain.common.entity.AuditableEntity;
 import lombok.Builder;
 import lombok.Getter;
@@ -12,10 +14,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @Getter
 @EntityListeners(AuditingEntityListener.class)
 public class User extends AuditableEntity {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
-
+    
     @Column(nullable = false, unique = true, length = 100)
     private String email;
 


### PR DESCRIPTION
<!-- (title: "[Type] Title close #IssueNumber") -->

## Motivation

<!-- 작성 배경 -->

- resolve #24

## Problem Solving

<!-- 해결 방법 -->

- AuditableEntity(상위 클래스)에 `@SQLDelete`, `@SQLRestriction` 어노테이션 제거
- 각 Entity(하위 클래스)에 `@SQLDelete`, `@SQLRestriction` 어노테이션 추가
- SoftDelete를 위해 email 중복 저장을 허용하고자 `email` 컬럼 unique 해제

## To Reviewer

<!-- 리뷰어에게 말하고 싶은 것, 유의 깊게 봐주었으면 하는 것, 의문점 등 -->

- Soft Delete 처리를 상위 클래스(`AuditableEntity`)에 적용하려고 했으나, 
  `@SQLDelete` 및 `@SQLRestriction`은 `@MappedSuperclass`에 선언해도 하위 엔티티에 반영되지 않아 동작하지 않았습니다.
- Hibernate 6.4부터 도입된 `@SoftDelete` 어노테이션도 실험적으로 테스트했지만, 
  현재 우리 프로젝트의 `deleted_at TIMESTAMP` 기반 전략과는 맞지 않아 적용이 어려웠습니다.
- 위 이유로 인해, 각 엔티티(`User`, `Post` 등)에 `@SQLDelete`, `@SQLRestriction`을 개별 선언하여 Soft Delete를 적용하였습니다.
- 더 나은 구조를 위한 리팩토링 아이디어가 있다면 편하게 코멘트 부탁드립니다!

### 실행 결과

<img width="430" alt="image" src="https://github.com/user-attachments/assets/7150d0c3-4d92-4766-a22f-f090d2fe602d" />