### PR TITLE
[Refactor] 공통 메시지를 위한 MessageCode Enum 도입 #28

### DIFF
--- a/src/main/java/kr/co/csalgo/application/auth/dto/EmailVerificationCodeDto.java
+++ b/src/main/java/kr/co/csalgo/application/auth/dto/EmailVerificationCodeDto.java
@@ -3,41 +3,45 @@ package kr.co.csalgo.application.auth.dto;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import kr.co.csalgo.common.message.MessageCode;
 import kr.co.csalgo.domain.auth.type.VerificationCodeType;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 public class EmailVerificationCodeDto {
-    @Getter
-    public static class Request {
-        @NotBlank(message = "이메일은 필수 입력 값입니다.")
-        @Email(message = "이메일 형식이 올바르지 않습니다.")
-        private String email;
+	@Getter
+	@NoArgsConstructor
+	public static class Request {
+		@NotBlank(message = "이메일은 필수 입력 값입니다.")
+		@Email(message = "이메일 형식이 올바르지 않습니다.")
+		private String email;
 
-        @NotNull(message = "인증 유형은 필수 입력 값입니다.")
-        private VerificationCodeType type;
+		@NotNull(message = "인증 유형은 필수 입력 값입니다.")
+		private VerificationCodeType type;
 
-        @Builder
-        public Request(String email, VerificationCodeType type) {
-            this.email = email;
-            this.type = type;
-        }
-    }
+		@Builder
+		public Request(String email, VerificationCodeType type) {
+			this.email = email;
+			this.type = type;
+		}
+	}
 
-    @Getter
-    public static class Response {
-        private String message;
+	@Getter
+	@NoArgsConstructor
+	public static class Response {
+		private String message;
 
-        @Builder
-        public Response(String message) {
-            this.message = message;
-        }
+		@Builder
+		public Response(String message) {
+			this.message = message;
+		}
 
-        public static Response of() {
-            return Response.builder()
-                    .message("인증번호가 성공적으로 전송되었습니다.")
-                    .build();
-        }
-    }
+		public static Response of() {
+			return Response.builder()
+				.message(MessageCode.EMAIL_SENT_SUCCESS.getMessage())
+				.build();
+		}
+	}
 
 }

--- a/src/main/java/kr/co/csalgo/application/user/dto/SubscriptionUseCaseDto.java
+++ b/src/main/java/kr/co/csalgo/application/user/dto/SubscriptionUseCaseDto.java
@@ -2,37 +2,39 @@ package kr.co.csalgo.application.user.dto;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
-import kr.co.csalgo.domain.user.entity.User;
+import kr.co.csalgo.common.message.MessageCode;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 public class SubscriptionUseCaseDto {
+	@Getter
+	@NoArgsConstructor
+	public static class Request {
+		@NotBlank(message = "이메일은 필수 입력 값입니다.")
+		@Email(message = "이메일 형식이 올바르지 않습니다.")
+		private String email;
 
-    @Getter
-    public static class Request {
-        @NotBlank(message = "이메일은 필수 입력 값입니다.")
-        @Email(message = "이메일 형식이 올바르지 않습니다.")
-        private String email;
+		@Builder
+		public Request(String email) {
+			this.email = email;
+		}
+	}
 
-        @Builder
-        public Request(String email) {
-            this.email = email;
-        }
-    }
+	@Getter
+	@NoArgsConstructor
+	public static class Response {
+		private String message;
 
-    @Getter
-    public static class Response {
-        private Long subscriptionId;
+		@Builder
+		public Response(String message) {
+			this.message = message;
+		}
 
-        @Builder
-        public Response(Long subscriptionId) {
-            this.subscriptionId = subscriptionId;
-        }
-
-        public static Response fromEntity(User user) {
-            return Response.builder()
-                    .subscriptionId(user.getId())
-                    .build();
-        }
-    }
+		public static Response of() {
+			return Response.builder()
+				.message(MessageCode.SUBSCRIBE_SUCCESS.getMessage())
+				.build();
+		}
+	}
 }

--- a/src/main/java/kr/co/csalgo/application/user/dto/UnsubscriptionUseCaseDto.java
+++ b/src/main/java/kr/co/csalgo/application/user/dto/UnsubscriptionUseCaseDto.java
@@ -2,36 +2,40 @@ package kr.co.csalgo.application.user.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
+import kr.co.csalgo.common.message.MessageCode;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 public class UnsubscriptionUseCaseDto {
-    @Getter
-    @Schema(name = "UnSubscriptionUseCaseDto.Request")
-    public static class Request {
-        @NotNull(message = "사용자 ID는 필수입니다.")
-        private final Long userId;
+	@Getter
+	@NoArgsConstructor
+	@Schema(name = "UnSubscriptionUseCaseDto.Request")
+	public static class Request {
+		@NotNull(message = "사용자 ID는 필수입니다.")
+		private Long userId;
 
-        @Builder
-        public Request(Long userId) {
-            this.userId = userId;
-        }
-    }
+		@Builder
+		public Request(Long userId) {
+			this.userId = userId;
+		}
+	}
 
-    @Getter
-    @Schema(name = "UnSubscriptionUseCaseDto.Response")
-    public static class Response {
-        private final String message;
+	@Getter
+	@NoArgsConstructor
+	@Schema(name = "UnSubscriptionUseCaseDto.Response")
+	public static class Response {
+		private String message;
 
-        @Builder
-        public Response(String message) {
-            this.message = message;
-        }
+		@Builder
+		public Response(String message) {
+			this.message = message;
+		}
 
-        public static Response of() {
-            return Response.builder()
-                    .message("구독이 성공적으로 해지되었습니다.")
-                    .build();
-        }
-    }
+		public static Response of() {
+			return Response.builder()
+				.message(MessageCode.UNSUBSCRIBE_SUCCESS.getMessage())
+				.build();
+		}
+	}
 }

--- a/src/main/java/kr/co/csalgo/application/user/usecase/SubscriptionUseCase.java
+++ b/src/main/java/kr/co/csalgo/application/user/usecase/SubscriptionUseCase.java
@@ -1,25 +1,26 @@
 package kr.co.csalgo.application.user.usecase;
 
+import org.springframework.stereotype.Service;
+
 import kr.co.csalgo.application.user.dto.SubscriptionUseCaseDto;
 import kr.co.csalgo.application.user.dto.UnsubscriptionUseCaseDto;
 import kr.co.csalgo.domain.user.entity.User;
 import kr.co.csalgo.domain.user.service.UserService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class SubscriptionUseCase {
 
-    private final UserService userService;
+	private final UserService userService;
 
-    public SubscriptionUseCaseDto.Response create(SubscriptionUseCaseDto.Request request) {
-        User user = userService.create(request.getEmail());
-        return SubscriptionUseCaseDto.Response.fromEntity(user);
-    }
+	public SubscriptionUseCaseDto.Response create(SubscriptionUseCaseDto.Request request) {
+		User user = userService.create(request.getEmail());
+		return SubscriptionUseCaseDto.Response.of();
+	}
 
-    public UnsubscriptionUseCaseDto.Response unsubscribe(UnsubscriptionUseCaseDto.Request request) {
-        userService.delete(request.getUserId());
-        return UnsubscriptionUseCaseDto.Response.of();
-    }
+	public UnsubscriptionUseCaseDto.Response unsubscribe(UnsubscriptionUseCaseDto.Request request) {
+		userService.delete(request.getUserId());
+		return UnsubscriptionUseCaseDto.Response.of();
+	}
 }

--- a/src/main/java/kr/co/csalgo/common/message/MessageCode.java
+++ b/src/main/java/kr/co/csalgo/common/message/MessageCode.java
@@ -1,0 +1,17 @@
+package kr.co.csalgo.common.message;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum MessageCode {
+	//구독 관련
+	SUBSCRIBE_SUCCESS("구독이 성공적으로 완료되었습니다."),
+	UNSUBSCRIBE_SUCCESS("구독이 성공적으로 해지되었습니다."),
+
+	// 인증 관련
+	EMAIL_SENT_SUCCESS("인증 메일이 성공적으로 전송되었습니다.");
+
+	private final String message;
+}

--- a/src/test/java/kr/co/csalgo/application/auth/usecase/EmailVerificationUseCaseTest.java
+++ b/src/test/java/kr/co/csalgo/application/auth/usecase/EmailVerificationUseCaseTest.java
@@ -1,9 +1,8 @@
 package kr.co.csalgo.application.auth.usecase;
 
-import kr.co.csalgo.application.auth.dto.EmailVerificationCodeDto;
-import kr.co.csalgo.domain.auth.service.VerificationCodeService;
-import kr.co.csalgo.domain.auth.type.VerificationCodeType;
-import kr.co.csalgo.infrastructure.email.service.EmailService;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -11,43 +10,45 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import kr.co.csalgo.application.auth.dto.EmailVerificationCodeDto;
+import kr.co.csalgo.common.message.MessageCode;
+import kr.co.csalgo.domain.auth.service.VerificationCodeService;
+import kr.co.csalgo.domain.auth.type.VerificationCodeType;
+import kr.co.csalgo.infrastructure.email.service.EmailService;
 
 @DisplayName("EmailVerificationUseCase Test")
 @ExtendWith(MockitoExtension.class)
 public class EmailVerificationUseCaseTest {
-    @Mock
-    private VerificationCodeService verificationCodeService;
-    @Mock
-    private EmailService emailService;
-    private EmailVerificationUseCase emailVerificationUseCase;
+	@Mock
+	private VerificationCodeService verificationCodeService;
+	@Mock
+	private EmailService emailService;
+	private EmailVerificationUseCase emailVerificationUseCase;
 
-    @BeforeEach
-    void setUp() {
-        emailVerificationUseCase = new EmailVerificationUseCase(verificationCodeService, emailService);
-    }
+	@BeforeEach
+	void setUp() {
+		emailVerificationUseCase = new EmailVerificationUseCase(verificationCodeService, emailService);
+	}
 
-    @Test
-    @DisplayName("이메일 인증번호 요청 테스트")
-    void testCreateVerificationCodeSuccess() {
-        String email = "test@example.com";
-        String code = "123456";
-        VerificationCodeType type = VerificationCodeType.SUBSCRIPTION;
+	@Test
+	@DisplayName("이메일 인증번호 요청 테스트")
+	void testCreateVerificationCodeSuccess() {
+		String email = "test@example.com";
+		String code = "123456";
+		VerificationCodeType type = VerificationCodeType.SUBSCRIPTION;
 
-        EmailVerificationCodeDto.Request request = EmailVerificationCodeDto.Request.builder()
-                .email(email)
-                .type(type)
-                .build();
+		EmailVerificationCodeDto.Request request = EmailVerificationCodeDto.Request.builder()
+			.email(email)
+			.type(type)
+			.build();
 
-        when(verificationCodeService.create(email, type)).thenReturn(code);
+		when(verificationCodeService.create(email, type)).thenReturn(code);
 
-        EmailVerificationCodeDto.Response response = emailVerificationUseCase.sendEmailVerificationCode(request);
+		EmailVerificationCodeDto.Response response = emailVerificationUseCase.sendEmailVerificationCode(request);
 
-        verify(verificationCodeService).create(email, type);
-        verify(emailService).sendEmail(email, code);
-        assertEquals("인증번호가 성공적으로 전송되었습니다.", response.getMessage());
-    }
+		verify(verificationCodeService).create(email, type);
+		verify(emailService).sendEmail(email, code);
+		assertEquals(MessageCode.EMAIL_SENT_SUCCESS.getMessage(), response.getMessage());
+	}
 
 }

--- a/src/test/java/kr/co/csalgo/presentation/subscription/SubscriptionControllerTest.java
+++ b/src/test/java/kr/co/csalgo/presentation/subscription/SubscriptionControllerTest.java
@@ -1,12 +1,11 @@
 package kr.co.csalgo.presentation.subscription;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import jakarta.transaction.Transactional;
-import kr.co.csalgo.application.user.dto.SubscriptionUseCaseDto;
-import kr.co.csalgo.application.user.dto.UnsubscriptionUseCaseDto;
-import kr.co.csalgo.application.user.usecase.SubscriptionUseCase;
-import kr.co.csalgo.common.exception.CustomBusinessException;
-import kr.co.csalgo.common.exception.ErrorCode;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -16,111 +15,114 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.transaction.Transactional;
+import kr.co.csalgo.application.user.dto.SubscriptionUseCaseDto;
+import kr.co.csalgo.application.user.dto.UnsubscriptionUseCaseDto;
+import kr.co.csalgo.application.user.usecase.SubscriptionUseCase;
+import kr.co.csalgo.common.exception.CustomBusinessException;
+import kr.co.csalgo.common.exception.ErrorCode;
+import kr.co.csalgo.common.message.MessageCode;
 
 @SpringBootTest
 @AutoConfigureMockMvc
 @Transactional
 public class SubscriptionControllerTest {
-    @Autowired
-    private MockMvc mockMvc;
+	@Autowired
+	private MockMvc mockMvc;
 
-    @MockitoBean
-    private SubscriptionUseCase subscriptionUseCase;
+	@MockitoBean
+	private SubscriptionUseCase subscriptionUseCase;
 
-    @Autowired
-    private ObjectMapper mapper;
+	@Autowired
+	private ObjectMapper mapper;
 
-    @Test
-    @DisplayName("사용자는 정상 이메일로 구독할 수 있다.")
-    void createSuccess() throws Exception {
-        SubscriptionUseCaseDto.Request request = SubscriptionUseCaseDto.Request.builder()
-                .email("team-jjins@gmail.com")
-                .build();
+	@Test
+	@DisplayName("사용자는 정상 이메일로 구독할 수 있다.")
+	void createSuccess() throws Exception {
+		SubscriptionUseCaseDto.Request request = SubscriptionUseCaseDto.Request.builder()
+			.email("team-jjins@gmail.com")
+			.build();
 
-        mockMvc.perform(post("/api/subscriptions")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(mapper.writeValueAsString(request)))
-                .andExpect(status().isOk())
-                .andDo(print());
-    }
+		mockMvc.perform(post("/api/subscriptions")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(mapper.writeValueAsString(request)))
+			.andExpect(status().isOk())
+			.andDo(print());
+	}
 
-    @Test
-    @DisplayName("중복된 이메일로는 구독할 수 없다.")
-    void duplicateEmail() throws Exception {
-        SubscriptionUseCaseDto.Request request = SubscriptionUseCaseDto.Request.builder()
-                .email("duplicate@gmail.com")
-                .build();
+	@Test
+	@DisplayName("중복된 이메일로는 구독할 수 없다.")
+	void duplicateEmail() throws Exception {
+		SubscriptionUseCaseDto.Request request = SubscriptionUseCaseDto.Request.builder()
+			.email("duplicate@gmail.com")
+			.build();
 
-        SubscriptionUseCaseDto.Response response = SubscriptionUseCaseDto.Response.builder()
-                .subscriptionId(1L)
-                .build();
+		SubscriptionUseCaseDto.Response response = SubscriptionUseCaseDto.Response.builder()
+			.message(MessageCode.SUBSCRIBE_SUCCESS.getMessage())
+			.build();
 
-        when(subscriptionUseCase.create(any()))
-                .thenReturn(response)
-                .thenThrow(new CustomBusinessException(ErrorCode.DUPLICATE_EMAIL));
+		when(subscriptionUseCase.create(any()))
+			.thenReturn(response)
+			.thenThrow(new CustomBusinessException(ErrorCode.DUPLICATE_EMAIL));
 
-        mockMvc.perform(post("/api/subscriptions")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(mapper.writeValueAsString(request)));
+		mockMvc.perform(post("/api/subscriptions")
+			.contentType(MediaType.APPLICATION_JSON)
+			.content(mapper.writeValueAsString(request)));
 
-        mockMvc.perform(post("/api/subscriptions")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(mapper.writeValueAsString(request)))
-                .andExpect(status().isConflict())
-                .andDo(print());
-    }
+		mockMvc.perform(post("/api/subscriptions")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(mapper.writeValueAsString(request)))
+			.andExpect(status().isConflict())
+			.andDo(print());
+	}
 
-    @Test
-    @DisplayName("이메일이 공백이면 구독할 수 없다.")
-    void blankEmail() throws Exception {
-        SubscriptionUseCaseDto.Request request = SubscriptionUseCaseDto.Request.builder()
-                .email("")
-                .build();
+	@Test
+	@DisplayName("이메일이 공백이면 구독할 수 없다.")
+	void blankEmail() throws Exception {
+		SubscriptionUseCaseDto.Request request = SubscriptionUseCaseDto.Request.builder()
+			.email("")
+			.build();
 
-        mockMvc.perform(post("/api/subscriptions")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(mapper.writeValueAsString(request)))
-                .andExpect(status().isBadRequest())
-                .andDo(print());
-    }
+		mockMvc.perform(post("/api/subscriptions")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(mapper.writeValueAsString(request)))
+			.andExpect(status().isBadRequest())
+			.andDo(print());
+	}
 
-    @Test
-    @DisplayName("올바르지 않은 이메일 형식으로는 구독할 수 없다.")
-    void invalidateEmailFormat() throws Exception {
-        SubscriptionUseCaseDto.Request request = SubscriptionUseCaseDto.Request.builder()
-                .email("team-jjinsgmail.com")
-                .build();
+	@Test
+	@DisplayName("올바르지 않은 이메일 형식으로는 구독할 수 없다.")
+	void invalidateEmailFormat() throws Exception {
+		SubscriptionUseCaseDto.Request request = SubscriptionUseCaseDto.Request.builder()
+			.email("team-jjinsgmail.com")
+			.build();
 
-        mockMvc.perform(post("/api/subscriptions")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(mapper.writeValueAsString(request)))
-                .andExpect(status().isBadRequest())
-                .andDo(print());
-    }
+		mockMvc.perform(post("/api/subscriptions")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(mapper.writeValueAsString(request)))
+			.andExpect(status().isBadRequest())
+			.andDo(print());
+	}
 
-    @Test
-    @DisplayName("구독 해지 성공")
-    void testUnsubscribeSuccess() throws Exception {
-        // given
-        UnsubscriptionUseCaseDto.Request request = UnsubscriptionUseCaseDto.Request.builder()
-                .userId(1L)
-                .build();
-        UnsubscriptionUseCaseDto.Response response = UnsubscriptionUseCaseDto.Response.of();
+	@Test
+	@DisplayName("구독 해지 성공")
+	void testUnsubscribeSuccess() throws Exception {
+		// given
+		UnsubscriptionUseCaseDto.Request request = UnsubscriptionUseCaseDto.Request.builder()
+			.userId(1L)
+			.build();
+		UnsubscriptionUseCaseDto.Response response = UnsubscriptionUseCaseDto.Response.of();
 
-        // when
-        when(subscriptionUseCase.unsubscribe(request)).thenReturn(response);
+		// when
+		when(subscriptionUseCase.unsubscribe(request)).thenReturn(response);
 
-        // then
-        mockMvc.perform(delete("/api/subscriptions")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .param("userId", String.valueOf(request.getUserId())))
-                .andExpect(status().isOk())
-                .andDo(print());
-    }
+		// then
+		mockMvc.perform(delete("/api/subscriptions")
+				.contentType(MediaType.APPLICATION_JSON)
+				.param("userId", String.valueOf(request.getUserId())))
+			.andExpect(status().isOk())
+			.andDo(print());
+	}
 }


### PR DESCRIPTION
<!-- (title: "[Type] Title close #IssueNumber") -->

## Motivation

<!-- 작성 배경 -->

- resolve #28 

## Problem Solving

<!-- 해결 방법 -->

- `MessageCode` enum을 생성하여 공통 응답 메시지 정의
- 구독 및 구독 해지 응답에서 기존 하드코딩된 메시지를 `MessageCode` 기반으로 교체
- swagger에 응답이 정상적으로 반환되는 지 확인.

## To Reviewer

<!-- 리뷰어에게 말하고 싶은 것, 유의 깊게 봐주었으면 하는 것, 의문점 등 -->

- enum으로 메세지 응답을 바꾸니, Jackson 역직렬화 오류 발생하여 dto request에 `@NoArgsConstructor` 추가했습니다.
- unsubscription api에서 userId가 null로 들어와서 별도 이슈로 처리하겠습니다.