### PR TITLE
[Chore] 어플리케이션 로깅 설정 #42

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ node_modules/
 
 ### Environment ###
 .env
+
+### Logs ###
+*.log

--- a/src/main/java/kr/co/csalgo/application/auth/usecase/EmailVerificationUseCase.java
+++ b/src/main/java/kr/co/csalgo/application/auth/usecase/EmailVerificationUseCase.java
@@ -7,22 +7,42 @@ import kr.co.csalgo.application.auth.dto.EmailVerificationVerifyDto;
 import kr.co.csalgo.domain.auth.service.VerificationCodeService;
 import kr.co.csalgo.infrastructure.email.service.EmailService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class EmailVerificationUseCase {
 	private final VerificationCodeService verificationCodeService;
 	private final EmailService emailService;
 
 	public EmailVerificationCodeDto.Response sendEmailVerificationCode(EmailVerificationCodeDto.Request request) {
-		String code = verificationCodeService.create(request.getEmail(), request.getType());
-		emailService.sendEmail(request.getEmail(), code);
+		String email = request.getEmail();
+		String type = request.getType().name();
+
+		log.info("[이메일 인증 코드 발송 시작] email={}, type={}", email, type);
+
+		String code = verificationCodeService.create(email, request.getType());
+
+		log.debug("인증 코드 생성 완료: email={}, code={}", email, code);
+
+		emailService.sendEmail(email, code);
+
+		log.info("[이메일 인증 코드 발송 완료] email={}", email);
+
 		return EmailVerificationCodeDto.Response.of();
 	}
 
 	public EmailVerificationVerifyDto.Response verifyEmailVerificationCode(
 		EmailVerificationVerifyDto.Request request) {
+
+		log.info("[이메일 인증 코드 검증 시작] email={}, type={}", request.getEmail(), request.getType());
+
 		verificationCodeService.verify(request.getEmail(), request.getCode(), request.getType());
+
+		log.info("[이메일 인증 코드 검증 성공] email={}, type={}", request.getEmail(), request.getType());
+
 		return EmailVerificationVerifyDto.Response.of();
 	}
+
 }

--- a/src/main/java/kr/co/csalgo/application/user/usecase/SubscriptionUseCase.java
+++ b/src/main/java/kr/co/csalgo/application/user/usecase/SubscriptionUseCase.java
@@ -7,20 +7,32 @@ import kr.co.csalgo.application.user.dto.UnsubscriptionUseCaseDto;
 import kr.co.csalgo.domain.user.entity.User;
 import kr.co.csalgo.domain.user.service.UserService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class SubscriptionUseCase {
 
 	private final UserService userService;
 
 	public SubscriptionUseCaseDto.Response create(SubscriptionUseCaseDto.Request request) {
+		log.info("[구독 요청] email={}", request.getEmail());
+
 		User user = userService.create(request.getEmail());
+
+		log.info("[구독 완료] userId={}, email={}", user.getId(), user.getEmail());
+
 		return SubscriptionUseCaseDto.Response.of();
 	}
 
 	public UnsubscriptionUseCaseDto.Response unsubscribe(UnsubscriptionUseCaseDto.Request request) {
+		log.info("[구독 해지 요청] userId={}", request.getUserId());
+
 		userService.delete(request.getUserId());
+
+		log.info("[구독 해지 완료] userId={}", request.getUserId());
+
 		return UnsubscriptionUseCaseDto.Response.of();
 	}
 }

--- a/src/main/java/kr/co/csalgo/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/kr/co/csalgo/common/exception/GlobalExceptionHandler.java
@@ -1,45 +1,88 @@
 package kr.co.csalgo.common.exception;
 
-import java.util.Objects;
+import java.util.Optional;
 
+import org.springframework.core.MethodParameter;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import lombok.extern.slf4j.Slf4j;
+
 @RestControllerAdvice
+@Slf4j
 public class GlobalExceptionHandler {
 
 	@ExceptionHandler(MethodArgumentNotValidException.class)
 	public ResponseEntity<ErrorResponse> handleValidation(MethodArgumentNotValidException exception) {
-		String detail = Objects.requireNonNull(exception.getBindingResult().getFieldError()).getDefaultMessage();
+		logException(exception, "WARN");
+		String message = Optional.ofNullable(exception.getBindingResult().getFieldError())
+			.map(FieldError::getDefaultMessage)
+			.orElse("잘못된 요청입니다.");
 		return ResponseEntity.badRequest()
-			.body(ErrorResponse.of(ErrorCode.INVALID_INPUT, detail));
+			.body(ErrorResponse.of(ErrorCode.INVALID_INPUT, message));
 	}
 
 	@ExceptionHandler(HttpMessageNotReadableException.class)
 	public ResponseEntity<ErrorResponse> handleMessageNotReadable(HttpMessageNotReadableException exception) {
-		String detail = exception.getMessage();
+		logException(exception, "WARN");
 		return ResponseEntity.badRequest()
-			.body(ErrorResponse.of(ErrorCode.MESSGAE_NOT_READABLE, detail));
+			.body(ErrorResponse.of(ErrorCode.MESSGAE_NOT_READABLE, exception.getMessage()));
 	}
 
 	@ExceptionHandler(IllegalArgumentException.class)
 	public ResponseEntity<ErrorResponse> handleIllegalArgument(IllegalArgumentException exception) {
-		return ResponseEntity.badRequest()
-			.body(ErrorResponse.of(ErrorCode.INVALID_INPUT, exception.getMessage()));
+		logException(exception, "WARN");
+		return ResponseEntity.badRequest().body(ErrorResponse.of(ErrorCode.INVALID_INPUT, exception.getMessage()));
 	}
 
 	@ExceptionHandler(CustomBusinessException.class)
 	public ResponseEntity<ErrorResponse> handleBusiness(CustomBusinessException exception) {
+		logException(exception, "WARN");
 		return ResponseEntity.status(exception.getErrorCode().getStatus())
 			.body(ErrorResponse.of(exception.getErrorCode(), exception.getMessage()));
 	}
 
 	@ExceptionHandler(Exception.class)
 	public ResponseEntity<ErrorResponse> handleException(Exception exception) {
+		logException(exception, "ERROR");
 		return ResponseEntity.internalServerError()
 			.body(ErrorResponse.of(ErrorCode.INTERNAL_SERVER_ERROR, exception.getMessage()));
+	}
+
+	private void logException(Exception ex, String logLevel) {
+		if (ex instanceof MethodArgumentNotValidException e) {
+			MethodParameter param = e.getParameter();
+			FieldError fieldError = e.getBindingResult().getFieldError();
+
+			String controller = param != null ? param.getDeclaringClass().getSimpleName() : "UnknownController";
+			String method = param != null ? param.getMethod().getName() : "unknownMethod";
+			String field = fieldError != null ? fieldError.getField() : "UnknownField";
+			String message = fieldError != null ? fieldError.getDefaultMessage() : "Invalid input";
+
+			String logMessage = String.format(
+				"Validation failed | controller=%s | method=%s | field=%s | message=%s",
+				controller, method, field, message
+			);
+			log(logLevel, logMessage);
+		} else {
+			String location = ex.getStackTrace().length > 0
+				? ex.getStackTrace()[0].toString()
+				: "UnknownLocation";
+			log(logLevel, "Exception occurred at {}: {}", location, ex.getMessage());
+		}
+	}
+
+	private void log(String level, String format, Object... args) {
+		switch (level) {
+			case "ERROR" -> log.error(format, args);
+			case "WARN" -> log.warn(format, args);
+			case "INFO" -> log.info(format, args);
+			case "DEBUG" -> log.debug(format, args);
+			default -> log.info(format, args);
+		}
 	}
 }

--- a/src/main/java/kr/co/csalgo/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/kr/co/csalgo/common/exception/GlobalExceptionHandler.java
@@ -36,7 +36,8 @@ public class GlobalExceptionHandler {
 	@ExceptionHandler(IllegalArgumentException.class)
 	public ResponseEntity<ErrorResponse> handleIllegalArgument(IllegalArgumentException exception) {
 		logException(exception, "WARN");
-		return ResponseEntity.badRequest().body(ErrorResponse.of(ErrorCode.INVALID_INPUT, exception.getMessage()));
+		return ResponseEntity.badRequest()
+			.body(ErrorResponse.of(ErrorCode.INVALID_INPUT, exception.getMessage()));
 	}
 
 	@ExceptionHandler(CustomBusinessException.class)
@@ -58,10 +59,10 @@ public class GlobalExceptionHandler {
 			MethodParameter param = e.getParameter();
 			FieldError fieldError = e.getBindingResult().getFieldError();
 
-			String controller = param != null ? param.getDeclaringClass().getSimpleName() : "UnknownController";
-			String method = param != null ? param.getMethod().getName() : "unknownMethod";
-			String field = fieldError != null ? fieldError.getField() : "UnknownField";
-			String message = fieldError != null ? fieldError.getDefaultMessage() : "Invalid input";
+			String controller = param.getContainingClass().getSimpleName();
+			String method = param.getMethod().getName();
+			String field = fieldError.getField();
+			String message = fieldError.getDefaultMessage();
 
 			String logMessage = String.format(
 				"Validation failed | controller=%s | method=%s | field=%s | message=%s",

--- a/src/main/java/kr/co/csalgo/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/kr/co/csalgo/common/exception/GlobalExceptionHandler.java
@@ -41,7 +41,7 @@ public class GlobalExceptionHandler {
 
 	@ExceptionHandler(CustomBusinessException.class)
 	public ResponseEntity<ErrorResponse> handleBusiness(CustomBusinessException exception) {
-		logException(exception, "WARN");
+		logException(exception, "INFO");
 		return ResponseEntity.status(exception.getErrorCode().getStatus())
 			.body(ErrorResponse.of(exception.getErrorCode(), exception.getMessage()));
 	}

--- a/src/main/java/kr/co/csalgo/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/kr/co/csalgo/common/exception/GlobalExceptionHandler.java
@@ -54,6 +54,7 @@ public class GlobalExceptionHandler {
 			.body(ErrorResponse.of(ErrorCode.INTERNAL_SERVER_ERROR, exception.getMessage()));
 	}
 
+	@SuppressWarnings("java:S2259")
 	private void logException(Exception ex, String logLevel) {
 		if (ex instanceof MethodArgumentNotValidException e) {
 			MethodParameter param = e.getParameter();

--- a/src/main/java/kr/co/csalgo/common/logging/TraceIdFilter.java
+++ b/src/main/java/kr/co/csalgo/common/logging/TraceIdFilter.java
@@ -1,0 +1,28 @@
+package kr.co.csalgo.common.logging;
+
+import java.io.IOException;
+import java.util.UUID;
+
+import org.slf4j.MDC;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+@Component
+public class TraceIdFilter extends OncePerRequestFilter {
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+		FilterChain filterChain) throws ServletException, IOException {
+		try {
+			String traceId = UUID.randomUUID().toString();
+			MDC.put("traceId", traceId);
+			filterChain.doFilter(request, response);
+		} finally {
+			MDC.clear();
+		}
+	}
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -54,3 +54,10 @@ management:
 
 springdoc:
   show-actuator: true
+
+logging:
+  level:
+    root: INFO
+    kr.co.csalgo: DEBUG
+  file:
+    name: logs/app.log

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -59,5 +59,6 @@ logging:
   level:
     root: INFO
     kr.co.csalgo: DEBUG
+    org.springframework.web.servlet.mvc.method.annotation.ExceptionHandlerExceptionResolver: ERROR
   file:
     name: logs/app.log

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,11 +1,32 @@
 <configuration>
+
+    <!-- 콘솔 로그 출력 -->
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level [%X{traceId:-no-trace}] %logger{36} - %msg%n
+            </pattern>
+        </encoder>
+    </appender>
+
+    <!-- 파일 로그 출력 및 롤링 -->
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>logs/app.log</file>
+
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>logs/app.%d{yyyy-MM-dd}.log</fileNamePattern>
+            <maxHistory>14</maxHistory>
+            <totalSizeCap>1GB</totalSizeCap>
+        </rollingPolicy>
+
         <encoder>
             <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level [%X{traceId}] %logger{36} - %msg%n</pattern>
         </encoder>
     </appender>
 
+    <!-- 루트 로거 설정 -->
     <root level="INFO">
         <appender-ref ref="CONSOLE"/>
+        <appender-ref ref="FILE"/>
     </root>
+
 </configuration>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -3,8 +3,7 @@
     <!-- 콘솔 로그 출력 -->
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level [%X{traceId:-no-trace}] %logger{36} - %msg%n
-            </pattern>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %highlight(%-5level) [%X{traceId:-no-trace}] %logger{36} - %msg%n</pattern>
         </encoder>
     </appender>
 

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,11 @@
+<configuration>
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level [%X{traceId}] %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+</configuration>


### PR DESCRIPTION
<!-- (title: "[Type] Title close #IssueNumber") -->

## Motivation

<!-- 작성 배경 -->

- resolves #42 

## Problem Solving

<!-- 해결 방법 -->

- 다중 인스턴스 확장을 고려하여 MDC에 TraceId 필드 추가 (5989e0bf857ce256cb9ed84ac7189fd1de911f9a)
    - MDC (Mapped Diagnostic Context): 로그 시스템에서 로그 메시지에 추가적인 정보를 담아 사용자에게 유용한 정보를 제공해주는 기능
- 기존 UseCase에 로그 추가 (info 레벨) (c80755b9e61af1a53e38d9eb6224530e1b1189c7, 9f865309d3568575171f55a1b33c7bd0eb76515b)
- 전역 예외 처리 핸들러에 로그 추가 (367bacb8a079033e01a9460387c47f705e4d2820)

## To Reviewer

<!-- 리뷰어에게 말하고 싶은 것, 유의 깊게 봐주었으면 하는 것, 의문점 등 -->

### 1. 로그 레벨 관련

현재 설정한 로그 레벨은 아래와 같습니다.

1. API 요청 성공 케이스 -> INFO 레벨
2. 커스텀 예외 발생 (요청을 처리하지 않지만 UX 관점에서 발생할 수 있는 케이스) -> INFO 레벨
3. 예외 발생 (handling을 하긴 하지만 정상적인 요청으로는 발생하지 않는 경우, 예: API 요청 시 argument가 빠져있음) -> WARN 레벨
4. 기타 예외 (개발자가 별도로 선언하지 못한 예외 발생, Exception) -> ERROR 레벨

로그 레벨에 대한 피드백 부탁드립니다!

### 2. 로깅 위치

현재는 로그를 application(UseCase)에서 출력하도록 함으로써 흐름상 중요한 결정 또는 결과를 출력하고자 하였는데, 이에 대해서도 피드백 주시면 감사하겠습니다.

### 3. 전역 예외 처리 시 `@SuppressWarnings("java:S2259")` 어노테이션 추가

`@SuppressWarnings("java:S2259")`는 SonarCloud의 S2259 규칙인 "Null pointers should not be dereferenced"에 대한 경고를 억제하기 위해 사용했습니다.

이 경고는 MethodParameter.getMethod()가 null을 반환할 수 있다고 추론한 것이지만, 실제로 이 메서드는 Spring MVC 실행 컨텍스트 내에서 보장된 상태에서 호출되며 null이 될 가능성은 없습니다.

Spring 공식 문서상 `@Nullable`로 선언되어 있지만, 현재 컨텍스트에서는 항상 유효한 Method 객체가 할당됨을 확인하였고, 실사용 중 NullPointerException이 발생할 가능성이 없다고 판단해 suppress 처리했습니다.

### 3. 로그 출력 예시

<img width="1841" alt="image" src="https://github.com/user-attachments/assets/6cdfd984-f546-425a-808c-6b022435efc4" />