### PR TITLE
[Fix] 이메일 인증 시나리오 중 코드 재전송 및 검증 버튼 불가 처리 #60

### DIFF
--- a/src/main/resources/static/js/subscription-modal.js
+++ b/src/main/resources/static/js/subscription-modal.js
@@ -2,6 +2,7 @@ import {postFormData} from './http.js';
 
 document.addEventListener("DOMContentLoaded", () => {
     const email = document.querySelector('#email');
+    const sendBtn = document.querySelector('#sendCodeBtn');
     const code = document.querySelector('#code');
     const submitBtn = document.querySelector('#submitBtn');
     const agreePolicy = document.querySelector('#agreePolicy');
@@ -30,7 +31,11 @@ document.addEventListener("DOMContentLoaded", () => {
 
         const {ok, data} = await postFormData('/subscription/request-code', {email: email.value});
         alert(data.message || (ok ? "코드가 전송되었습니다." : "실패했습니다."));
-        if (ok) email.disabled = true;
+
+        if (ok) {
+            email.disabled = true;
+            sendBtn.disabled = true;
+        }
     });
 
     document.querySelector('#verifyCodeBtn')?.addEventListener('click', async () => {


### PR DESCRIPTION
<!-- (title: "[Type] Title close #IssueNumber") -->

## Motivation

<!-- 작성 배경 -->

- resolves #60 

## Problem Solving

<!-- 해결 방법 -->

- 이메일 인증 코드 전송 이후로 재전송 불가 처리
- 이메일 검증 성공 후 재검증 불가 처리

## To Reviewer

<!-- 리뷰어에게 말하고 싶은 것, 유의 깊게 봐주었으면 하는 것, 의문점 등 -->

<img width="300" alt="image" src="https://github.com/user-attachments/assets/82e5aef8-4590-48a8-8f2a-6f47cb662ee4" />

- 기존 시스템의 허점인 '이메일 인증 코드 전송' 후 재전송이 가능한 상황을 불가능하도록 처리하였습니다.
	- 이는 서버 리소스를 불필요하게 소모하거나, 악의적인 트래픽 유발 가능성이 있을 수 있고, 현재 API 요청 및 응답 상황에서 딜레이기 있어 사용자 경험 측면에서도 실수로 여러 번 인증을 요청할 수 있는 상황을 방지하고자 하였습니다.
	- 따라서 인증 코드 전송 이후에는 버튼을 비활성화하여 재전송을 명시적으로 차단하고, 페이지를 새로고침 해야 다시 요청할 수 있도록 제한함으로써, 보안성과 사용자 경험을 모두 고려하여 개선 사항을 반영하였습니다.