### PR TITLE
[Feature] 문제 전송 API 구현 #63

### DIFF
--- a/src/main/java/kr/co/csalgo/application/auth/dto/EmailVerificationCodeDto.java
+++ b/src/main/java/kr/co/csalgo/application/auth/dto/EmailVerificationCodeDto.java
@@ -39,7 +39,7 @@ public class EmailVerificationCodeDto {
 
 		public static Response of() {
 			return Response.builder()
-				.message(MessageCode.EMAIL_SENT_SUCCESS.getMessage())
+				.message(MessageCode.SEND_PROBLEM_MAIL_SUCCESS.getMessage())
 				.build();
 		}
 	}

--- a/src/main/java/kr/co/csalgo/application/auth/dto/EmailVerificationCodeDto.java
+++ b/src/main/java/kr/co/csalgo/application/auth/dto/EmailVerificationCodeDto.java
@@ -39,7 +39,7 @@ public class EmailVerificationCodeDto {
 
 		public static Response of() {
 			return Response.builder()
-				.message(MessageCode.SEND_PROBLEM_MAIL_SUCCESS.getMessage())
+				.message(MessageCode.EMAIL_SENT_SUCCESS.getMessage())
 				.build();
 		}
 	}

--- a/src/main/java/kr/co/csalgo/application/auth/usecase/EmailVerificationUseCase.java
+++ b/src/main/java/kr/co/csalgo/application/auth/usecase/EmailVerificationUseCase.java
@@ -26,7 +26,7 @@ public class EmailVerificationUseCase {
 
 		log.debug("인증 코드 생성 완료: email={}, code={}", email, code);
 
-		emailService.sendEmail(email, code);
+		emailService.sendVerificationCode(email, code);
 
 		log.info("[이메일 인증 코드 발송 완료] email={}", email);
 

--- a/src/main/java/kr/co/csalgo/application/problem/dto/SendProblemMailDto.java
+++ b/src/main/java/kr/co/csalgo/application/problem/dto/SendProblemMailDto.java
@@ -1,0 +1,49 @@
+package kr.co.csalgo.application.problem.dto;
+
+import java.time.LocalDateTime;
+
+import jakarta.validation.constraints.Future;
+import jakarta.validation.constraints.NotNull;
+import kr.co.csalgo.common.message.MessageCode;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class SendProblemMailDto {
+	@Getter
+	@NoArgsConstructor
+	public static class Request {
+		@NotNull(message = "문제 ID는 필수입니다.")
+		private Long problemId;
+
+		private Long userId;
+
+		@Future(message = "예약 발송 시간은 현재보다 미래여야 합니다.")
+		private LocalDateTime scheduledTime;
+
+		@Builder
+		public Request(Long problemId, Long userId, LocalDateTime scheduledTime) {
+			this.problemId = problemId;
+			this.userId = userId;
+			this.scheduledTime = scheduledTime;
+		}
+	}
+
+	@Getter
+	@NoArgsConstructor
+	public static class Response {
+		private String message;
+
+		@Builder
+		public Response(String message) {
+			this.message = message;
+		}
+
+		public static Response of() {
+			return Response.builder()
+				.message(MessageCode.SEND_PROBLEM_MAIL_SUCCESS.getMessage())
+				.build();
+		}
+	}
+}
+

--- a/src/main/java/kr/co/csalgo/application/problem/dto/SendQuestionMailDto.java
+++ b/src/main/java/kr/co/csalgo/application/problem/dto/SendQuestionMailDto.java
@@ -9,12 +9,12 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-public class SendProblemMailDto {
+public class SendQuestionMailDto {
 	@Getter
 	@NoArgsConstructor
 	public static class Request {
 		@NotNull(message = "문제 ID는 필수입니다.")
-		private Long problemId;
+		private Long questionId;
 
 		private Long userId;
 
@@ -22,8 +22,8 @@ public class SendProblemMailDto {
 		private LocalDateTime scheduledTime;
 
 		@Builder
-		public Request(Long problemId, Long userId, LocalDateTime scheduledTime) {
-			this.problemId = problemId;
+		public Request(Long questionId, Long userId, LocalDateTime scheduledTime) {
+			this.questionId = questionId;
 			this.userId = userId;
 			this.scheduledTime = scheduledTime;
 		}
@@ -41,7 +41,7 @@ public class SendProblemMailDto {
 
 		public static Response of() {
 			return Response.builder()
-				.message(MessageCode.SEND_PROBLEM_MAIL_SUCCESS.getMessage())
+				.message(MessageCode.SEND_QUESTION_MAIL_SUCCESS.getMessage())
 				.build();
 		}
 	}

--- a/src/main/java/kr/co/csalgo/application/problem/usecase/SendQuestionMailUseCase.java
+++ b/src/main/java/kr/co/csalgo/application/problem/usecase/SendQuestionMailUseCase.java
@@ -1,0 +1,68 @@
+package kr.co.csalgo.application.problem.usecase;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.stereotype.Service;
+
+import kr.co.csalgo.application.problem.dto.SendQuestionMailDto;
+import kr.co.csalgo.domain.question.entity.Question;
+import kr.co.csalgo.domain.question.service.QuestionSendingHistoryService;
+import kr.co.csalgo.domain.question.service.QuestionService;
+import kr.co.csalgo.domain.user.entity.User;
+import kr.co.csalgo.domain.user.service.UserService;
+import kr.co.csalgo.infrastructure.email.service.EmailService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class SendQuestionMailUseCase {
+	private final QuestionSendingHistoryService questionSendingHistoryService;
+	private final QuestionService questionService;
+	private final UserService userService;
+	private final EmailService mailService;
+	private final ScheduledExecutorService scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
+
+	public SendQuestionMailDto.Response execute(SendQuestionMailDto.Request request) {
+		Long questionId = request.getQuestionId();
+		Long userId = request.getUserId();
+		LocalDateTime scheduledTime = request.getScheduledTime();
+
+		log.info("[문제 메일 발송 요청] qusetionId: {}, userId: {}, scheduledTime: {}", questionId, userId, scheduledTime);
+
+		Question question = questionService.read(questionId);
+		User user = userId != null ? userService.read(userId) : null;
+
+		Runnable task = () -> {
+			if (user != null) {
+				// TODO: 메일 발송 로직 추가 필요
+				questionSendingHistoryService.create(question.getId(), user.getId());
+				log.info("[문제 메일 발송 완료] questionId: {}, userId: {}", question.getId(), user.getId());
+			} else {
+				log.info("[문제 메일 발송] 전체 사용자에게 발송 예정 - questionId: {}", question.getId());
+				List<User> users = userService.list();
+				for (User u : users) {
+					// TODO: 메일 발송 로직 추가 필요
+					questionSendingHistoryService.create(question.getId(), u.getId());
+					log.info("[문제 메일 발송 완료] questionId: {}, userId: {}", question.getId(), u.getId());
+				}
+			}
+		};
+
+		if (request.getScheduledTime() != null) {
+			long delay = Duration.between(LocalDateTime.now(), request.getScheduledTime()).toMillis();
+			scheduledExecutorService.schedule(task, delay, TimeUnit.MILLISECONDS);
+			log.info("[예약 메일 전송 예약됨] delay(ms)={}", delay);
+		} else {
+			task.run();
+		}
+
+		return SendQuestionMailDto.Response.of();
+	}
+}

--- a/src/main/java/kr/co/csalgo/application/problem/usecase/SendQuestionMailUseCase.java
+++ b/src/main/java/kr/co/csalgo/application/problem/usecase/SendQuestionMailUseCase.java
@@ -41,14 +41,14 @@ public class SendQuestionMailUseCase {
 
 		Runnable task = () -> {
 			if (user != null) {
-				// TODO: 메일 발송 로직 추가 필요
+				mailService.sendEmail(user.getEmail(), "[CS-ALGO] %s".formatted(question.getTitle()), question.getTitle());
 				questionSendingHistoryService.create(question.getId(), user.getId());
 				log.info("[문제 메일 발송 완료] questionId: {}, userId: {}", question.getId(), user.getId());
 			} else {
 				log.info("[문제 메일 발송] 전체 사용자에게 발송 예정 - questionId: {}", question.getId());
 				List<User> users = userService.list();
 				for (User u : users) {
-					// TODO: 메일 발송 로직 추가 필요
+					mailService.sendEmail(u.getEmail(), "[CS-ALGO] %s".formatted(question.getTitle()), question.getTitle());
 					questionSendingHistoryService.create(question.getId(), u.getId());
 					log.info("[문제 메일 발송 완료] questionId: {}, userId: {}", question.getId(), u.getId());
 				}

--- a/src/main/java/kr/co/csalgo/application/problem/usecase/SendQuestionMailUseCase.java
+++ b/src/main/java/kr/co/csalgo/application/problem/usecase/SendQuestionMailUseCase.java
@@ -29,7 +29,7 @@ public class SendQuestionMailUseCase {
 	private final UserService userService;
 	private final EmailService mailService;
 
-	private final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor(); // 또는 주입
+	private final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
 
 	public SendQuestionMailDto.Response execute(SendQuestionMailDto.Request request) {
 		Long questionId = request.getQuestionId();

--- a/src/main/java/kr/co/csalgo/common/exception/ErrorCode.java
+++ b/src/main/java/kr/co/csalgo/common/exception/ErrorCode.java
@@ -11,12 +11,15 @@ import lombok.Getter;
 public enum ErrorCode {
 	// A: 일반 요청 오류
 	INVALID_INPUT("A001", HttpStatus.BAD_REQUEST, "잘못된 입력값입니다."),
-	MESSGAE_NOT_READABLE("A002", HttpStatus.BAD_REQUEST, "요청 본문을 읽을 수 없습니다.."),
+	MESSAGE_NOT_READABLE("A002", HttpStatus.BAD_REQUEST, "요청 본문을 읽을 수 없습니다.."),
 
 	// B: 비즈니스 로직 오류
 	USER_NOT_FOUND("B001", HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
 	DUPLICATE_EMAIL("B002", HttpStatus.CONFLICT, "이메일이 이미 등록되어 있습니다."),
 	VERIFICATION_CODE_MISMATCH("B003", HttpStatus.BAD_REQUEST, "인증 코드가 일치하지 않습니다."),
+
+	// C: 문제 관련 오류
+	QUESTION_NOT_FOUND("C001", HttpStatus.NOT_FOUND, "문제를 찾을 수 없습니다."),
 
 	// Z: 시스템 오류
 	INTERNAL_SERVER_ERROR("Z001", HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다.");

--- a/src/main/java/kr/co/csalgo/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/kr/co/csalgo/common/exception/GlobalExceptionHandler.java
@@ -30,7 +30,7 @@ public class GlobalExceptionHandler {
 	public ResponseEntity<ErrorResponse> handleMessageNotReadable(HttpMessageNotReadableException exception) {
 		logException(exception, "WARN");
 		return ResponseEntity.badRequest()
-			.body(ErrorResponse.of(ErrorCode.MESSGAE_NOT_READABLE, exception.getMessage()));
+			.body(ErrorResponse.of(ErrorCode.MESSAGE_NOT_READABLE, exception.getMessage()));
 	}
 
 	@ExceptionHandler(IllegalArgumentException.class)

--- a/src/main/java/kr/co/csalgo/common/message/MessageCode.java
+++ b/src/main/java/kr/co/csalgo/common/message/MessageCode.java
@@ -15,7 +15,7 @@ public enum MessageCode {
 	EMAIL_VERIFICATION_SUCCESS("이메일 인증이 성공적으로 완료되었습니다."),
 
 	// 문제 관련
-	SEND_PROBLEM_MAIL_SUCCESS("문제 메일이 성공적으로 발송(예약)되었습니다.");
+	SEND_QUESTION_MAIL_SUCCESS("문제 메일이 성공적으로 발송(예약)되었습니다.");
 
 	private final String message;
 }

--- a/src/main/java/kr/co/csalgo/common/message/MessageCode.java
+++ b/src/main/java/kr/co/csalgo/common/message/MessageCode.java
@@ -12,7 +12,10 @@ public enum MessageCode {
 
 	// 인증 관련
 	EMAIL_SENT_SUCCESS("인증 메일이 성공적으로 전송되었습니다."),
-	EMAIL_VERIFICATION_SUCCESS("이메일 인증이 성공적으로 완료되었습니다.");
+	EMAIL_VERIFICATION_SUCCESS("이메일 인증이 성공적으로 완료되었습니다."),
+
+	// 문제 관련
+	SEND_PROBLEM_MAIL_SUCCESS("문제 메일이 성공적으로 발송(예약)되었습니다.");
 
 	private final String message;
 }

--- a/src/main/java/kr/co/csalgo/domain/question/repository/QuestionRepository.java
+++ b/src/main/java/kr/co/csalgo/domain/question/repository/QuestionRepository.java
@@ -1,9 +1,11 @@
 package kr.co.csalgo.domain.question.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import kr.co.csalgo.domain.question.entity.Question;
 
 public interface QuestionRepository extends JpaRepository<Question, Long> {
-	boolean existsById(Long id);
+	Optional<Question> findById(Long id);
 }

--- a/src/main/java/kr/co/csalgo/domain/question/repository/QuestionRepository.java
+++ b/src/main/java/kr/co/csalgo/domain/question/repository/QuestionRepository.java
@@ -1,0 +1,9 @@
+package kr.co.csalgo.domain.question.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import kr.co.csalgo.domain.question.entity.Question;
+
+public interface QuestionRepository extends JpaRepository<Question, Long> {
+	boolean existsById(Long id);
+}

--- a/src/main/java/kr/co/csalgo/domain/question/repository/QuestionSendingHistoryRepository.java
+++ b/src/main/java/kr/co/csalgo/domain/question/repository/QuestionSendingHistoryRepository.java
@@ -1,0 +1,8 @@
+package kr.co.csalgo.domain.question.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import kr.co.csalgo.domain.question.entity.QuestionSendingHistory;
+
+public interface QuestionSendingHistoryRepository extends JpaRepository<QuestionSendingHistory, Long> {
+}

--- a/src/main/java/kr/co/csalgo/domain/question/service/QuestionSendingHistoryService.java
+++ b/src/main/java/kr/co/csalgo/domain/question/service/QuestionSendingHistoryService.java
@@ -1,0 +1,19 @@
+package kr.co.csalgo.domain.question.service;
+
+import org.springframework.stereotype.Service;
+
+import kr.co.csalgo.domain.question.entity.QuestionSendingHistory;
+import kr.co.csalgo.domain.question.repository.QuestionSendingHistoryRepository;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class QuestionSendingHistoryService {
+	private final QuestionSendingHistoryRepository questionSendingHistoryRepository;
+
+	public QuestionSendingHistory create(QuestionSendingHistory questionSendingHistory) {
+		// TODO: 1. 문제 존재 여부 검증
+		// TODO: 2. 유저 존재 여부 검증
+		return questionSendingHistoryRepository.save(questionSendingHistory);
+	}
+}

--- a/src/main/java/kr/co/csalgo/domain/question/service/QuestionSendingHistoryService.java
+++ b/src/main/java/kr/co/csalgo/domain/question/service/QuestionSendingHistoryService.java
@@ -2,18 +2,30 @@ package kr.co.csalgo.domain.question.service;
 
 import org.springframework.stereotype.Service;
 
+import kr.co.csalgo.domain.question.entity.Question;
 import kr.co.csalgo.domain.question.entity.QuestionSendingHistory;
 import kr.co.csalgo.domain.question.repository.QuestionSendingHistoryRepository;
+import kr.co.csalgo.domain.user.entity.User;
+import kr.co.csalgo.domain.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
 public class QuestionSendingHistoryService {
 	private final QuestionSendingHistoryRepository questionSendingHistoryRepository;
+	private final QuestionService questionService;
+	private final UserService userService;
 
-	public QuestionSendingHistory create(QuestionSendingHistory questionSendingHistory) {
-		// TODO: 1. 문제 존재 여부 검증
-		// TODO: 2. 유저 존재 여부 검증
+	public QuestionSendingHistory create(Long questionId, Long userId) {
+		Question question = questionService.read(questionId);
+
+		User user = userService.read(userId);
+
+		QuestionSendingHistory questionSendingHistory = QuestionSendingHistory.builder()
+			.question(question)
+			.user(user)
+			.build();
+
 		return questionSendingHistoryRepository.save(questionSendingHistory);
 	}
 }

--- a/src/main/java/kr/co/csalgo/domain/question/service/QuestionService.java
+++ b/src/main/java/kr/co/csalgo/domain/question/service/QuestionService.java
@@ -1,0 +1,16 @@
+package kr.co.csalgo.domain.question.service;
+
+import org.springframework.stereotype.Service;
+
+import kr.co.csalgo.domain.question.repository.QuestionRepository;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class QuestionService {
+	private final QuestionRepository questionRepository;
+
+	public boolean isExists(Long id) {
+		return questionRepository.existsById(id);
+	}
+}

--- a/src/main/java/kr/co/csalgo/domain/question/service/QuestionService.java
+++ b/src/main/java/kr/co/csalgo/domain/question/service/QuestionService.java
@@ -2,6 +2,9 @@ package kr.co.csalgo.domain.question.service;
 
 import org.springframework.stereotype.Service;
 
+import kr.co.csalgo.common.exception.CustomBusinessException;
+import kr.co.csalgo.common.exception.ErrorCode;
+import kr.co.csalgo.domain.question.entity.Question;
 import kr.co.csalgo.domain.question.repository.QuestionRepository;
 import lombok.RequiredArgsConstructor;
 
@@ -10,7 +13,8 @@ import lombok.RequiredArgsConstructor;
 public class QuestionService {
 	private final QuestionRepository questionRepository;
 
-	public boolean isExists(Long id) {
-		return questionRepository.existsById(id);
+	public Question read(Long id) {
+		return questionRepository.findById(id)
+			.orElseThrow(() -> new CustomBusinessException(ErrorCode.QUESTION_NOT_FOUND));
 	}
 }

--- a/src/main/java/kr/co/csalgo/domain/user/service/UserService.java
+++ b/src/main/java/kr/co/csalgo/domain/user/service/UserService.java
@@ -25,6 +25,11 @@ public class UserService {
 		return user;
 	}
 
+	public User read(Long id) {
+		return userRepository.findById(id)
+			.orElseThrow(() -> new CustomBusinessException(ErrorCode.USER_NOT_FOUND));
+	}
+
 	public void delete(UUID uuid) {
 		User user = userRepository.findByUuid(uuid)
 			.orElseThrow(() -> new CustomBusinessException(ErrorCode.USER_NOT_FOUND));

--- a/src/main/java/kr/co/csalgo/domain/user/service/UserService.java
+++ b/src/main/java/kr/co/csalgo/domain/user/service/UserService.java
@@ -1,5 +1,6 @@
 package kr.co.csalgo.domain.user.service;
 
+import java.util.List;
 import java.util.UUID;
 
 import org.springframework.stereotype.Service;
@@ -34,6 +35,10 @@ public class UserService {
 		User user = userRepository.findByUuid(uuid)
 			.orElseThrow(() -> new CustomBusinessException(ErrorCode.USER_NOT_FOUND));
 		userRepository.delete(user);
+	}
+
+	public List<User> list() {
+		return userRepository.findAll();
 	}
 
 	private void checkDuplicateEmail(String email) {

--- a/src/main/java/kr/co/csalgo/infrastructure/email/service/EmailService.java
+++ b/src/main/java/kr/co/csalgo/infrastructure/email/service/EmailService.java
@@ -15,7 +15,7 @@ public class EmailService {
 
 	private final JavaMailSender mailSender;
 
-	public void sendEmail(String email, String code) {
+	public void sendVerificationCode(String email, String code) {
 		try {
 			MimeMessage message = mailSender.createMimeMessage();
 			MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");

--- a/src/main/java/kr/co/csalgo/infrastructure/email/service/EmailService.java
+++ b/src/main/java/kr/co/csalgo/infrastructure/email/service/EmailService.java
@@ -15,6 +15,21 @@ public class EmailService {
 
 	private final JavaMailSender mailSender;
 
+	public void sendEmail(String email, String subject, String content) {
+		try {
+			MimeMessage message = mailSender.createMimeMessage();
+			MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
+
+			helper.setTo(email);
+			helper.setSubject(subject);
+			helper.setText(content, true);
+
+			mailSender.send(message);
+		} catch (Exception e) {
+			throw new CustomBusinessException(ErrorCode.INTERNAL_SERVER_ERROR);
+		}
+	}
+
 	public void sendVerificationCode(String email, String code) {
 		try {
 			MimeMessage message = mailSender.createMimeMessage();

--- a/src/main/java/kr/co/csalgo/presentation/question/QuestionController.java
+++ b/src/main/java/kr/co/csalgo/presentation/question/QuestionController.java
@@ -1,0 +1,34 @@
+package kr.co.csalgo.presentation.question;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.Valid;
+import kr.co.csalgo.application.problem.dto.SendQuestionMailDto;
+import kr.co.csalgo.application.problem.usecase.SendQuestionMailUseCase;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/question")
+public class QuestionController {
+	private final SendQuestionMailUseCase sendQuestionMailUseCase;
+
+	@PostMapping("/send")
+	@Operation(summary = "문제 메일 전송", description = "사용자가 문제를 확인할 수 있도록 메일을 전송합니다.")
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "메일 전송 성공"),
+		@ApiResponse(responseCode = "400", description = "잘못된 요청 (유효성 검사 실패 등)"),
+		@ApiResponse(responseCode = "404", description = "문제 또는 사용자 정보가 존재하지 않음"),
+	})
+	public ResponseEntity<?> sendQuestionMail(@Valid @RequestBody SendQuestionMailDto.Request request) {
+		return ResponseEntity.ok(sendQuestionMailUseCase.execute(request));
+	}
+}
+

--- a/src/test/java/kr/co/csalgo/application/auth/usecase/EmailVerificationUseCaseTest.java
+++ b/src/test/java/kr/co/csalgo/application/auth/usecase/EmailVerificationUseCaseTest.java
@@ -48,7 +48,7 @@ public class EmailVerificationUseCaseTest {
 		EmailVerificationCodeDto.Response response = emailVerificationUseCase.sendEmailVerificationCode(request);
 
 		verify(verificationCodeService).create(email, type);
-		verify(emailService).sendEmail(email, code);
+		verify(emailService).sendVerificationCode(email, code);
 		assertEquals(MessageCode.EMAIL_SENT_SUCCESS.getMessage(), response.getMessage());
 	}
 

--- a/src/test/java/kr/co/csalgo/application/problem/usecase/SendQuestionMailUseCaseTest.java
+++ b/src/test/java/kr/co/csalgo/application/problem/usecase/SendQuestionMailUseCaseTest.java
@@ -1,0 +1,109 @@
+package kr.co.csalgo.application.problem.usecase;
+
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+import java.util.concurrent.ScheduledExecutorService;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import kr.co.csalgo.application.problem.dto.SendQuestionMailDto;
+import kr.co.csalgo.domain.question.entity.Question;
+import kr.co.csalgo.domain.question.service.QuestionSendingHistoryService;
+import kr.co.csalgo.domain.question.service.QuestionService;
+import kr.co.csalgo.domain.user.entity.User;
+import kr.co.csalgo.domain.user.service.UserService;
+import kr.co.csalgo.infrastructure.email.service.EmailService;
+
+@DisplayName("SendQuestionMailUseCase Test")
+class SendQuestionMailUseCaseTest {
+
+	@Mock
+	private QuestionSendingHistoryService questionSendingHistoryService;
+	@Mock
+	private QuestionService questionService;
+	@Mock
+	private UserService userService;
+	@Mock
+	private EmailService emailService;
+	@Mock
+	private ScheduledExecutorService scheduler;
+
+	@InjectMocks
+	private SendQuestionMailUseCase useCase;
+
+	@BeforeEach
+	void setUp() {
+		MockitoAnnotations.openMocks(this);
+		useCase = new SendQuestionMailUseCase(
+			questionSendingHistoryService,
+			questionService,
+			userService,
+			emailService
+		);
+	}
+
+	@Test
+	@DisplayName("userId가 주어졌을 때 즉시 메일 발송 테스트")
+	void testSendImmediatelyToUser() {
+		// given
+		Long questionId = 1L;
+		Long userId = 10L;
+
+		Question mockQuestion = new Question();
+		ReflectionTestUtils.setField(mockQuestion, "id", questionId);
+		ReflectionTestUtils.setField(mockQuestion, "title", "Test Title");
+
+		User mockUser = new User("test@csalgo.com");
+		ReflectionTestUtils.setField(mockUser, "id", userId);
+
+		when(questionService.read(questionId)).thenReturn(mockQuestion);
+		when(userService.read(userId)).thenReturn(mockUser);
+
+		SendQuestionMailDto.Request request = SendQuestionMailDto.Request.builder()
+			.questionId(questionId)
+			.userId(userId)
+			.build();
+
+		// when
+		useCase.execute(request);
+
+		// then
+		verify(emailService).sendEmail(eq("test@csalgo.com"), anyString(), anyString());
+		verify(questionSendingHistoryService).create(eq(questionId), eq(userId));
+	}
+
+	@Test
+	@DisplayName("userId 없이 전체 사용자에게 메일 발송 테스트")
+	void testSendToAllUsers() {
+		// given
+		Long questionId = 3L;
+
+		Question mockQuestion = new Question();
+		ReflectionTestUtils.setField(mockQuestion, "id", questionId);
+		ReflectionTestUtils.setField(mockQuestion, "title", "전체 발송 문제");
+
+		User mockUser = new User("test@csalgo.com");
+		ReflectionTestUtils.setField(mockUser, "id", 999L);
+
+		when(questionService.read(questionId)).thenReturn(mockQuestion);
+		when(userService.list()).thenReturn(List.of(mockUser));
+
+		SendQuestionMailDto.Request request = SendQuestionMailDto.Request.builder()
+			.questionId(questionId)
+			.build();
+
+		// when
+		useCase.execute(request);
+
+		// then
+		verify(emailService).sendEmail(eq("test@csalgo.com"), anyString(), anyString());
+		verify(questionSendingHistoryService).create(eq(questionId), eq(999L));
+	}
+}

--- a/src/test/java/kr/co/csalgo/common/exception/GlobalExceptionHandlerTest.java
+++ b/src/test/java/kr/co/csalgo/common/exception/GlobalExceptionHandlerTest.java
@@ -71,8 +71,8 @@ class GlobalExceptionHandlerTest {
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(malformedJson))
 			.andExpect(status().isBadRequest())
-			.andExpect(jsonPath("$.code").value(ErrorCode.MESSGAE_NOT_READABLE.getCode()))
-			.andExpect(jsonPath("$.message").value(ErrorCode.MESSGAE_NOT_READABLE.getMessage()))
+			.andExpect(jsonPath("$.code").value(ErrorCode.MESSAGE_NOT_READABLE.getCode()))
+			.andExpect(jsonPath("$.message").value(ErrorCode.MESSAGE_NOT_READABLE.getMessage()))
 			.andExpect(jsonPath("$.timestamp").exists());
 	}
 

--- a/src/test/java/kr/co/csalgo/domain/question/service/QuestionSendingHistoryServiceTest.java
+++ b/src/test/java/kr/co/csalgo/domain/question/service/QuestionSendingHistoryServiceTest.java
@@ -1,0 +1,81 @@
+package kr.co.csalgo.domain.question.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import kr.co.csalgo.domain.question.entity.Question;
+import kr.co.csalgo.domain.question.entity.QuestionSendingHistory;
+import kr.co.csalgo.domain.question.repository.QuestionSendingHistoryRepository;
+import kr.co.csalgo.domain.user.entity.User;
+import kr.co.csalgo.domain.user.service.UserService;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("QuestionSendingHistoryService Test")
+class QuestionSendingHistoryServiceTest {
+
+	@Mock
+	private QuestionSendingHistoryRepository questionSendingHistoryRepository;
+
+	@Mock
+	private QuestionService questionService;
+
+	@Mock
+	private UserService userService;
+
+	private QuestionSendingHistoryService questionSendingHistoryService;
+
+	@BeforeEach
+	void setUp() {
+		questionSendingHistoryService = new QuestionSendingHistoryService(
+			questionSendingHistoryRepository,
+			questionService,
+			userService
+		);
+	}
+
+	@Test
+	@DisplayName("정상적으로 문제 전송 기록을 생성할 수 있다.")
+	void testCreateHistorySuccess() {
+		// given
+
+		Question question = Question.builder()
+			.title("What is TDD?")
+			.build();
+
+		User user = User.builder()
+			.email("test@example.com")
+			.build();
+
+		QuestionSendingHistory history = QuestionSendingHistory.builder()
+			.question(question)
+			.user(user)
+			.build();
+
+		when(questionService.read(anyLong())).thenReturn(question);
+		when(userService.read(anyLong())).thenReturn(user);
+		when(questionSendingHistoryRepository.save(any())).thenReturn(history);
+
+		// when
+		QuestionSendingHistory result = questionSendingHistoryService.create(1L, 1L);
+
+		// then
+		assertNotNull(result);
+		assertEquals(question, result.getQuestion());
+		assertEquals(user, result.getUser());
+
+		// verify save call
+		ArgumentCaptor<QuestionSendingHistory> captor = ArgumentCaptor.forClass(QuestionSendingHistory.class);
+		verify(questionSendingHistoryRepository).save(captor.capture());
+		QuestionSendingHistory captured = captor.getValue();
+		assertEquals(question, captured.getQuestion());
+		assertEquals(user, captured.getUser());
+	}
+}

--- a/src/test/java/kr/co/csalgo/domain/question/service/QuestionServiceTest.java
+++ b/src/test/java/kr/co/csalgo/domain/question/service/QuestionServiceTest.java
@@ -1,0 +1,70 @@
+package kr.co.csalgo.domain.question.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import kr.co.csalgo.common.exception.CustomBusinessException;
+import kr.co.csalgo.common.exception.ErrorCode;
+import kr.co.csalgo.domain.question.entity.Question;
+import kr.co.csalgo.domain.question.repository.QuestionRepository;
+
+@DisplayName("QuestionService Test")
+@ExtendWith(MockitoExtension.class)
+class QuestionServiceTest {
+
+	@Mock
+	private QuestionRepository questionRepository;
+
+	private QuestionService questionService;
+
+	@BeforeEach
+	void setUp() {
+		questionService = new QuestionService(questionRepository);
+	}
+
+	@Test
+	@DisplayName("존재하는 ID로 질문을 조회할 수 있다.")
+	void testReadQuestionSuccess() {
+		// given
+		Long id = 1L;
+		Question question = Question.builder()
+			.title("Sample Question")
+			.description("This is a sample question description.")
+			.solution("Sample solution code here.")
+			.build();
+
+		when(questionRepository.findById(id)).thenReturn(Optional.of(question));
+
+		// when
+		Question result = questionService.read(id);
+
+		// then
+		assertNotNull(result);
+		assertEquals("Sample Question", result.getTitle());
+		verify(questionRepository).findById(id);
+	}
+
+	@Test
+	@DisplayName("존재하지 않는 ID로 질문 조회 시 예외가 발생한다.")
+	void testReadQuestionNotFound() {
+		// given
+		Long id = 999L;
+		when(questionRepository.findById(id)).thenReturn(Optional.empty());
+
+		// when & then
+		CustomBusinessException exception = assertThrows(CustomBusinessException.class, () -> {
+			questionService.read(id);
+		});
+		assertEquals(ErrorCode.QUESTION_NOT_FOUND, exception.getErrorCode());
+		verify(questionRepository).findById(id);
+	}
+}

--- a/src/test/java/kr/co/csalgo/domain/user/service/UserServiceTest.java
+++ b/src/test/java/kr/co/csalgo/domain/user/service/UserServiceTest.java
@@ -3,6 +3,7 @@ package kr.co.csalgo.domain.user.service;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -91,5 +92,55 @@ class UserServiceTest {
 		assertThrows(CustomBusinessException.class, () -> {
 			userService.delete(unregisteredUuid);
 		});
+	}
+
+	@Test
+	@DisplayName("존재하는 ID로 사용자를 조회할 수 있다.")
+	void testReadUserSuccess() {
+		// given
+		Long userId = 1L;
+		String email = "read@example.com";
+		User user = User.builder().email(email).build();
+		when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+
+		// when
+		User result = userService.read(userId);
+
+		// then
+		assertNotNull(result);
+		assertEquals(email, result.getEmail());
+		verify(userRepository).findById(userId);
+	}
+
+	@Test
+	@DisplayName("존재하지 않는 ID로 사용자 조회 시 예외가 발생한다.")
+	void testReadUserNotFound() {
+		// given
+		Long invalidUserId = 999L;
+		when(userRepository.findById(invalidUserId)).thenReturn(Optional.empty());
+
+		// when & then
+		assertThrows(CustomBusinessException.class, () -> userService.read(invalidUserId));
+		verify(userRepository).findById(invalidUserId);
+	}
+
+	@Test
+	@DisplayName("전체 사용자 목록을 반환한다.")
+	void testListUsers() {
+		// given
+		List<User> users = List.of(
+			User.builder().email("user1@example.com").build(),
+			User.builder().email("user2@example.com").build()
+		);
+		when(userRepository.findAll()).thenReturn(users);
+
+		// when
+		List<User> result = userService.list();
+
+		// then
+		assertEquals(2, result.size());
+		assertEquals("user1@example.com", result.get(0).getEmail());
+		assertEquals("user2@example.com", result.get(1).getEmail());
+		verify(userRepository).findAll();
 	}
 }

--- a/src/test/java/kr/co/csalgo/infrastructure/email/service/EmailServiceTest.java
+++ b/src/test/java/kr/co/csalgo/infrastructure/email/service/EmailServiceTest.java
@@ -41,7 +41,7 @@ public class EmailServiceTest {
 		doThrow(new MailSendException("전송 오류")).when(javaMailSender).send(any(MimeMessage.class));
 
 		CustomBusinessException exception = assertThrows(CustomBusinessException.class, () ->
-			emailService.sendEmail(email, code));
+			emailService.sendVerificationCode(email, code));
 
 		assertEquals(ErrorCode.INTERNAL_SERVER_ERROR, exception.getErrorCode());
 	}

--- a/src/test/java/kr/co/csalgo/presentation/auth/EmailVerificationControllerTest.java
+++ b/src/test/java/kr/co/csalgo/presentation/auth/EmailVerificationControllerTest.java
@@ -44,7 +44,7 @@ public class EmailVerificationControllerTest {
 
 	@BeforeEach
 	void setUp() {
-		doNothing().when(emailService).sendEmail(anyString(), anyString());
+		doNothing().when(emailService).sendVerificationCode(anyString(), anyString());
 	}
 
 	@Test

--- a/src/test/java/kr/co/csalgo/presentation/question/QuestionControllerTest.java
+++ b/src/test/java/kr/co/csalgo/presentation/question/QuestionControllerTest.java
@@ -1,0 +1,103 @@
+package kr.co.csalgo.presentation.question;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+import jakarta.transaction.Transactional;
+import kr.co.csalgo.application.problem.dto.SendQuestionMailDto;
+import kr.co.csalgo.application.problem.usecase.SendQuestionMailUseCase;
+import kr.co.csalgo.common.exception.CustomBusinessException;
+import kr.co.csalgo.common.exception.ErrorCode;
+import kr.co.csalgo.common.message.MessageCode;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+public class QuestionControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@MockitoBean
+	private SendQuestionMailUseCase sendQuestionMailUseCase;
+
+	private final ObjectMapper mapper = new ObjectMapper().registerModule(new JavaTimeModule());
+
+	@Test
+	@DisplayName("특정 사용자에게 문제 메일 전송 성공 시 200 OK를 반환한다")
+	void sendToSingleUserSuccess() throws Exception {
+		SendQuestionMailDto.Request request = SendQuestionMailDto.Request.builder()
+			.questionId(1L)
+			.userId(28L)
+			.build();
+
+		when(sendQuestionMailUseCase.execute(any()))
+			.thenReturn(SendQuestionMailDto.Response.of());
+
+		mockMvc.perform(post("/api/question/send")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(mapper.writeValueAsString(request)))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.message").value(MessageCode.SEND_QUESTION_MAIL_SUCCESS.getMessage()));
+	}
+
+	@Test
+	@DisplayName("전체 사용자에게 문제 메일 전송 성공 시 200 OK를 반환한다")
+	void sendToAllUsersSuccess() throws Exception {
+		SendQuestionMailDto.Request request = SendQuestionMailDto.Request.builder()
+			.questionId(1L)
+			.build(); // userId 없음 → 전체 발송
+
+		when(sendQuestionMailUseCase.execute(any()))
+			.thenReturn(SendQuestionMailDto.Response.of());
+
+		mockMvc.perform(post("/api/question/send")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(mapper.writeValueAsString(request)))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.message").value(MessageCode.SEND_QUESTION_MAIL_SUCCESS.getMessage()));
+	}
+
+	@Test
+	@DisplayName("존재하지 않는 질문으로 요청 시 404 Not Found를 반환한다")
+	void sendQuestionNotFound() throws Exception {
+		SendQuestionMailDto.Request request = SendQuestionMailDto.Request.builder()
+			.questionId(999L)
+			.userId(28L)
+			.build();
+
+		when(sendQuestionMailUseCase.execute(any()))
+			.thenThrow(new CustomBusinessException(ErrorCode.QUESTION_NOT_FOUND));
+
+		mockMvc.perform(post("/api/question/send")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(mapper.writeValueAsString(request)))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.message").value(ErrorCode.QUESTION_NOT_FOUND.getMessage()));
+	}
+
+	@Test
+	@DisplayName("이메일 전송 요청 시 questionId가 없으면 400 Bad Request를 반환한다")
+	void missingQuestionId() throws Exception {
+		String invalidJson = "{ 'userId': 28 }";
+
+		mockMvc.perform(post("/api/question/send")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(invalidJson))
+			.andExpect(status().isBadRequest());
+	}
+}


### PR DESCRIPTION
<!-- (title: "[Type] Title close #IssueNumber") -->

## Motivation

<!-- 작성 배경 -->

- resolves #63 

## Problem Solving

<!-- 해결 방법 -->

- `questionId`, `userId`, `scheduledTime`의 입력값에 따라 세 가지 전송 시나리오를 처리하도록 설계했습니다.
  1. `userId`, `scheduledTime` 모두 없을 경우: 즉시 전체 사용자에게 발송
  2. `userId`만 있을 경우: 즉시 해당 사용자에게 발송
  3. `userId`, `scheduledTime` 모두 있을 경우: 예약 전송
- 예약 전송의 경우 `ScheduledExecutorService`를 사용해 요청 시점과 예약 시간 간 차이를 계산하여 지연 실행을 구현했습니다.
- 전송이 완료되면 `QuestionSendingHistory`를 생성하여 문제 전송 이력을 저장합니다.
- 메일 전송에는 `EmailService`를 활용하며, 제목과 본문은 문제 제목을 기반으로 구성됩니다.

## To Reviewer

<!-- 리뷰어에게 말하고 싶은 것, 유의 깊게 봐주었으면 하는 것, 의문점 등 -->

- 사전에 우리가 API Request, Response, URI에 대한 설계를 하지 않았기 때문에, 코드 리뷰를 통해 검토해주시면 감사하겠습니다.

### 실행 결과

| Postman | Gmail |
| --- | --- |
| <img width="511" alt="image" src="https://github.com/user-attachments/assets/0c9052a7-16e9-4db2-b931-ace9ab3361f4" /> | <img width="578" alt="image" src="https://github.com/user-attachments/assets/4b451f92-47cb-4635-85dc-df6924b148ea" /> |