### PR TITLE
[Feature] Scheduler 기반 문제 메일 자동 발송 기능 구현 #62

### DIFF
--- a/src/main/java/kr/co/csalgo/CsAlgoApplication.java
+++ b/src/main/java/kr/co/csalgo/CsAlgoApplication.java
@@ -3,8 +3,10 @@ package kr.co.csalgo;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableJpaAuditing
+@EnableScheduling
 @SpringBootApplication
 public class CsAlgoApplication {
 

--- a/src/main/java/kr/co/csalgo/application/problem/usecase/SendDailyQuestionMailUseCase.java
+++ b/src/main/java/kr/co/csalgo/application/problem/usecase/SendDailyQuestionMailUseCase.java
@@ -1,0 +1,64 @@
+package kr.co.csalgo.application.problem.usecase;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import kr.co.csalgo.domain.question.entity.Question;
+import kr.co.csalgo.domain.question.service.QuestionSendingHistoryService;
+import kr.co.csalgo.domain.question.service.QuestionService;
+import kr.co.csalgo.domain.user.entity.User;
+import kr.co.csalgo.domain.user.service.UserService;
+import kr.co.csalgo.infrastructure.email.service.EmailService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class SendDailyQuestionMailUseCase {
+	private final UserService userService;
+	private final QuestionService questionService;
+	private final QuestionSendingHistoryService questionSendingHistoryService;
+	private final EmailService mailService;
+
+	public void execute() {
+		log.info("[스케쥴러 문제 전송 시작] 전체 유저 대상");
+		List<Question> allQuestions = questionService.list();
+
+		if (allQuestions.isEmpty()) {
+			log.warn("[문제 전송 스킵] 등록된 문제가 없음.");
+			return;
+		}
+
+		List<User> users = userService.list();
+		for (User user : users) {
+			try {
+				Question selected = selectQuestion(user, allQuestions);
+				sendMail(selected, user);
+
+			} catch (Exception e) {
+				log.error("[문제 전송 실패] userId: {}", user.getId(), e);
+			}
+		}
+
+	}
+
+	private Question selectQuestion(User user, List<Question> questions) {
+		long sentCount = questionSendingHistoryService.count(user);
+		int index = (int)(sentCount % questions.size());
+		Question selected = questions.get(index);
+		log.info("[문제 선택] questionId: {}, userId: {}", selected.getId(), user.getId());
+		return selected;
+	}
+
+	private void sendMail(Question question, User user) {
+		String subject = "[CS-ALGO] %s".formatted(question.getTitle());
+		String body = question.getTitle();
+
+		mailService.sendEmail(user.getEmail(), subject, body);
+		questionSendingHistoryService.create(question.getId(), user.getId());
+
+		log.info("[문제 메일 발송 완료] questionId: {}, userId: {}", question.getId(), user.getId());
+	}
+}

--- a/src/main/java/kr/co/csalgo/domain/question/repository/QuestionSendingHistoryRepository.java
+++ b/src/main/java/kr/co/csalgo/domain/question/repository/QuestionSendingHistoryRepository.java
@@ -3,6 +3,8 @@ package kr.co.csalgo.domain.question.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import kr.co.csalgo.domain.question.entity.QuestionSendingHistory;
+import kr.co.csalgo.domain.user.entity.User;
 
 public interface QuestionSendingHistoryRepository extends JpaRepository<QuestionSendingHistory, Long> {
+	long countByUser(User user);
 }

--- a/src/main/java/kr/co/csalgo/domain/question/service/QuestionSendingHistoryService.java
+++ b/src/main/java/kr/co/csalgo/domain/question/service/QuestionSendingHistoryService.java
@@ -28,4 +28,8 @@ public class QuestionSendingHistoryService {
 
 		return questionSendingHistoryRepository.save(questionSendingHistory);
 	}
+
+	public long count(User user) {
+		return questionSendingHistoryRepository.countByUser(user);
+	}
 }

--- a/src/main/java/kr/co/csalgo/domain/question/service/QuestionService.java
+++ b/src/main/java/kr/co/csalgo/domain/question/service/QuestionService.java
@@ -1,5 +1,7 @@
 package kr.co.csalgo.domain.question.service;
 
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 
 import kr.co.csalgo.common.exception.CustomBusinessException;
@@ -16,5 +18,9 @@ public class QuestionService {
 	public Question read(Long id) {
 		return questionRepository.findById(id)
 			.orElseThrow(() -> new CustomBusinessException(ErrorCode.QUESTION_NOT_FOUND));
+	}
+
+	public List<Question> list() {
+		return questionRepository.findAll();
 	}
 }

--- a/src/main/java/kr/co/csalgo/infrastructure/question/QuestionScheduler.java
+++ b/src/main/java/kr/co/csalgo/infrastructure/question/QuestionScheduler.java
@@ -1,0 +1,20 @@
+package kr.co.csalgo.infrastructure.question;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import kr.co.csalgo.application.problem.usecase.SendDailyQuestionMailUseCase;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class QuestionScheduler {
+
+	private final SendDailyQuestionMailUseCase sendDailyQuestionMailUseCase;
+
+	@Scheduled(cron = "0 0 8 * * *", zone = "Asia/Seoul")
+	public void run() {
+		sendDailyQuestionMailUseCase.execute();
+	}
+}
+

--- a/src/test/java/kr/co/csalgo/application/problem/usecase/SendDailyQuestionMailUseCaseTest.java
+++ b/src/test/java/kr/co/csalgo/application/problem/usecase/SendDailyQuestionMailUseCaseTest.java
@@ -1,0 +1,118 @@
+package kr.co.csalgo.application.problem.usecase;
+
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import kr.co.csalgo.domain.question.entity.Question;
+import kr.co.csalgo.domain.question.service.QuestionSendingHistoryService;
+import kr.co.csalgo.domain.question.service.QuestionService;
+import kr.co.csalgo.domain.user.entity.User;
+import kr.co.csalgo.domain.user.service.UserService;
+import kr.co.csalgo.infrastructure.email.service.EmailService;
+
+@DisplayName("SendDailyQuestionMailUseCase 테스트")
+class SendDailyQuestionMailUseCaseTest {
+	@Mock
+	private QuestionSendingHistoryService questionSendingHistoryService;
+	@Mock
+	private QuestionService questionService;
+	@Mock
+	private UserService userService;
+	@Mock
+	private EmailService emailService;
+
+	@InjectMocks
+	SendDailyQuestionMailUseCase sendDailyQuestionMailUseCase;
+
+	@BeforeEach
+	void setUp() {
+		MockitoAnnotations.openMocks(this);
+		sendDailyQuestionMailUseCase = new SendDailyQuestionMailUseCase(
+			userService,
+			questionService,
+			questionSendingHistoryService,
+			emailService
+		);
+	}
+
+	@Test
+	@DisplayName("전체 사용자에게 문제를 전송한다.")
+	void testExecuteSuccess() {
+		User user1 = createUser(1L, "u1@test.com");
+		User user2 = createUser(2L, "u2@test.com");
+
+		Question q1 = createQuestion(101L, "Q1");
+		Question q2 = createQuestion(102L, "Q2");
+
+		when(questionService.list()).thenReturn(List.of(q1, q2));
+		when(userService.list()).thenReturn(List.of(user1, user2));
+		when(questionSendingHistoryService.count(user1)).thenReturn(0L);
+		when(questionSendingHistoryService.count(user2)).thenReturn(1L);
+
+		sendDailyQuestionMailUseCase.execute();
+
+		verify(emailService).sendEmail(eq("u1@test.com"), contains("Q1"), any());
+		verify(emailService).sendEmail(eq("u2@test.com"), contains("Q2"), any());
+		verify(questionSendingHistoryService).create(101L, 1L);
+		verify(questionSendingHistoryService).create(102L, 2L);
+	}
+
+	@Test
+	@DisplayName("질문이 없으면 전체 사용자에게 메일을 보내지 않는다")
+	void testNoQuestions() {
+		when(questionService.list()).thenReturn(List.of());
+
+		sendDailyQuestionMailUseCase.execute();
+
+		verify(userService, never()).list();
+		verify(emailService, never()).sendEmail(any(), any(), any());
+	}
+
+	@Test
+	@DisplayName("한 명에게 메일 전송 실패해도 다른 사용자에게는 정상 발송한다.")
+	void testExecute_EmailFailForOneUser_OthersStillReceive_Failure() {
+		User user1 = createUser(1L, "fail@test.com");
+		User user2 = createUser(2L, "ok@test.com");
+		Question question = createQuestion(200L, "질문");
+
+		when(questionService.list()).thenReturn(List.of(question));
+		when(userService.list()).thenReturn(List.of(user1, user2));
+		when(questionSendingHistoryService.count(any())).thenReturn(0L);
+
+		doThrow(new RuntimeException("메일 전송 실패"))
+			.when(emailService).sendEmail(eq("fail@test.com"), any(), any());
+
+		sendDailyQuestionMailUseCase.execute();
+
+		verify(emailService).sendEmail(eq("fail@test.com"), any(), any());
+		verify(emailService).sendEmail(eq("ok@test.com"), any(), any());
+		verify(questionSendingHistoryService).create(200L, 2L);
+	}
+
+	private User createUser(Long id, String email) {
+		User user = User.builder()
+			.email(email)
+			.build();
+		ReflectionTestUtils.setField(user, "id", id);
+		return user;
+	}
+
+	private Question createQuestion(Long id, String title) {
+		Question question = Question.builder()
+			.title(title)
+			.description("description")
+			.solution("solution")
+			.build();
+		ReflectionTestUtils.setField(question, "id", id);
+		return question;
+	}
+}

--- a/src/test/java/kr/co/csalgo/domain/question/service/QuestionSendingHistoryServiceTest.java
+++ b/src/test/java/kr/co/csalgo/domain/question/service/QuestionSendingHistoryServiceTest.java
@@ -78,4 +78,21 @@ class QuestionSendingHistoryServiceTest {
 		assertEquals(question, captured.getQuestion());
 		assertEquals(user, captured.getUser());
 	}
+
+	@Test
+	@DisplayName("사용자에게 보낸 문제 수를 가져온다.")
+	void testCountByUser() {
+		User user = User.builder()
+			.email("test@csalgo.com")
+			.build();
+		long expectedCount = 5L;
+
+		when(questionSendingHistoryRepository.countByUser(user)).thenReturn(expectedCount);
+
+		long result = questionSendingHistoryService.count(user);
+
+		assertEquals(expectedCount, result);
+		verify(questionSendingHistoryRepository).countByUser(user);
+	}
+
 }

--- a/src/test/java/kr/co/csalgo/domain/question/service/QuestionServiceTest.java
+++ b/src/test/java/kr/co/csalgo/domain/question/service/QuestionServiceTest.java
@@ -3,6 +3,7 @@ package kr.co.csalgo.domain.question.service;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -66,5 +67,31 @@ class QuestionServiceTest {
 		});
 		assertEquals(ErrorCode.QUESTION_NOT_FOUND, exception.getErrorCode());
 		verify(questionRepository).findById(id);
+	}
+
+	@Test
+	@DisplayName("모든 질문을 조회할 수 있다.")
+	void testListQuestions() {
+
+		Question question1 = Question.builder()
+			.title("Question 1")
+			.description("Desc 1")
+			.solution("Solution 1")
+			.build();
+
+		Question question2 = Question.builder()
+			.title("Question 2")
+			.description("Desc 2")
+			.solution("Solution 2")
+			.build();
+
+		when(questionRepository.findAll()).thenReturn(List.of(question1, question2));
+
+		List<Question> result = questionService.list();
+
+		assertEquals(2, result.size());
+		assertEquals("Question 1", result.get(0).getTitle());
+		assertEquals("Question 2", result.get(1).getTitle());
+		verify(questionRepository).findAll();
 	}
 }

--- a/src/test/java/kr/co/csalgo/infrastructure/question/QuestionSchedulerTest.java
+++ b/src/test/java/kr/co/csalgo/infrastructure/question/QuestionSchedulerTest.java
@@ -1,0 +1,34 @@
+package kr.co.csalgo.infrastructure.question;
+
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import kr.co.csalgo.application.problem.usecase.SendDailyQuestionMailUseCase;
+
+@DisplayName("QuestionScheduler 테스트")
+class QuestionSchedulerTest {
+
+	@Mock
+	private SendDailyQuestionMailUseCase useCase;
+	@InjectMocks
+	private QuestionScheduler scheduler;
+
+	@BeforeEach
+	void setUp() {
+		MockitoAnnotations.openMocks(this);
+		scheduler = new QuestionScheduler(useCase);
+	}
+
+	@Test
+	@DisplayName("매일 8시에 execute가 실행된다.")
+	void testScheduler_Run_Success() {
+		scheduler.run();
+		verify(useCase, times(1)).execute();
+	}
+}


### PR DESCRIPTION
<!-- (title: "[Type] Title close #IssueNumber") -->

## Motivation

<!-- 작성 배경 -->

- resolve #62 

## Problem Solving

<!-- 해결 방법 -->

- `SendDailyQuestionMailUseCase` 클래스에서 전체 사용자 리스트를 조회한 후, 각 사용자의 문제 전송 이력을 기반으로 순차적으로 문제를 선택
  - 문제는 전체 리스트(삭제된 것 제외) 중 `(전송 이력 수 % 전체 문제 수)` 방식으로 선택, 모든 문제를 수신한 경우 다시 첫문제로
  - 전송 성공 시 `questionSendingHistory`에 기록을 남기고, 전송 실패 시 로그만 남기며 다음 사용자 진행
- 매일 오전 8시에 `infra > QuestionScheduler`에서 위의 usecase의 execute를 실행

## To Reviewer

<!-- 리뷰어에게 말하고 싶은 것, 유의 깊게 봐주었으면 하는 것, 의문점 등 -->

문제 선택 방식
 - 모든 사용자에게 동일한 문제를 전송하는 방식도 고려했지만, 그러면 `QuestionSendingHistory` 가 필요없다고 생각해서 현재 구조를 유지했습니다. 
 - 문제 전송 시 사용자마다 약간의 딜레이가 발생하는 점.
 - 문제 선택 방식, 최적화면에서 더 나은 방향이 있다면 피드백 부탁드립니다!

| 로그 | 메일 수신 확인 |
|--|--|
| ![스크린샷 2025-06-04 173952](https://github.com/user-attachments/assets/e40c4dd9-a8f5-4b63-8193-f3798deb33b9) | ![스크린샷 2025-06-04 193931](https://github.com/user-attachments/assets/ce01dc8a-22e3-466a-8a1c-7a5e9618c33f)|
