### PR TITLE
[Feature] 사용자 응답 피드백 메일 전송 #73

### DIFF
--- a/src/main/java/kr/co/csalgo/application/mail/usecase/SendFeedbackMailUseCase.java
+++ b/src/main/java/kr/co/csalgo/application/mail/usecase/SendFeedbackMailUseCase.java
@@ -22,6 +22,10 @@ public class SendFeedbackMailUseCase {
 			.toList();
 
 		// TODO: 2. 피드백이 전송되지 않은 문제에 대해 피드백 메일 전송
+		for (QuestionResponse response : feedbackResponses) {
+			// 피드백 메일 전송 로직 구현
+		}
+
 		// TODO: 3. 피드백 메일 처리에 대한 로깅
 	}
 }

--- a/src/main/java/kr/co/csalgo/application/mail/usecase/SendFeedbackMailUseCase.java
+++ b/src/main/java/kr/co/csalgo/application/mail/usecase/SendFeedbackMailUseCase.java
@@ -1,0 +1,15 @@
+package kr.co.csalgo.application.mail.usecase;
+
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Service
+public class SendFeedbackMailUseCase {
+	public void execute() {
+		// TODO: 1. 피드백이 전송되지 않은 문제 List 조회
+		// TODO: 2. 피드백이 전송되지 않은 문제에 대해 피드백 메일 전송
+		// TODO: 3. 피드백 메일 처리에 대한 로깅
+	}
+}

--- a/src/main/java/kr/co/csalgo/application/mail/usecase/SendFeedbackMailUseCase.java
+++ b/src/main/java/kr/co/csalgo/application/mail/usecase/SendFeedbackMailUseCase.java
@@ -4,16 +4,25 @@ import java.util.List;
 
 import org.springframework.stereotype.Service;
 
+import kr.co.csalgo.common.util.MailTemplate;
+import kr.co.csalgo.domain.email.EmailSender;
 import kr.co.csalgo.domain.question.entity.QuestionResponse;
+import kr.co.csalgo.domain.question.entity.ResponseFeedback;
+import kr.co.csalgo.domain.question.feedback.FeedbackAnalyzer;
+import kr.co.csalgo.domain.question.feedback.FeedbackResult;
 import kr.co.csalgo.domain.question.service.QuestionResponseService;
 import kr.co.csalgo.domain.question.service.ResponseFeedbackService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
-@RequiredArgsConstructor
 @Service
+@RequiredArgsConstructor
+@Slf4j
 public class SendFeedbackMailUseCase {
 	private final QuestionResponseService questionResponseService;
 	private final ResponseFeedbackService responseFeedbackService;
+	private final FeedbackAnalyzer feedbackAnalyzer;
+	private final EmailSender emailSender;
 
 	public void execute() {
 		List<QuestionResponse> responses = questionResponseService.list();
@@ -21,9 +30,29 @@ public class SendFeedbackMailUseCase {
 			.filter(response -> !responseFeedbackService.isFeedbackExists(response))
 			.toList();
 
-		// TODO: 2. 피드백이 전송되지 않은 문제에 대해 피드백 메일 전송
+		int successCount = 0;
+		int failCount = 0;
+
 		for (QuestionResponse response : feedbackResponses) {
-			// 피드백 메일 전송 로직 구현
+			try {
+				ResponseFeedback result = responseFeedbackService.create(response, "피드백 내용");
+
+				FeedbackResult feedbackResult = feedbackAnalyzer.analyze(response.getContent(), response.getQuestion().getSolution());
+
+				emailSender.send(
+					response.getUser().getEmail(),
+					MailTemplate.FEEDBACK_MAIL_SUBJECT.formatted(response.getQuestion().getTitle()),
+					MailTemplate.formatFeedbackMailBody(
+						response.getUser().getEmail().split("@")[0],
+						feedbackResult.getResponseContent(),
+						feedbackResult.getQuestionSolution()
+					));
+				log.info("피드백 메일 전송 성공: responseId={}, feedbackId={}", response.getId(), result.getId());
+				successCount++;
+			} catch (Exception e) {
+				log.error("피드백 메일 전송 실패: responseId={}, error={}", response.getId(), e.getMessage(), e);
+				failCount++;
+			}
 		}
 
 		// TODO: 3. 피드백 메일 처리에 대한 로깅

--- a/src/main/java/kr/co/csalgo/application/mail/usecase/SendFeedbackMailUseCase.java
+++ b/src/main/java/kr/co/csalgo/application/mail/usecase/SendFeedbackMailUseCase.java
@@ -1,14 +1,26 @@
 package kr.co.csalgo.application.mail.usecase;
 
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 
+import kr.co.csalgo.domain.question.entity.QuestionResponse;
+import kr.co.csalgo.domain.question.service.QuestionResponseService;
+import kr.co.csalgo.domain.question.service.ResponseFeedbackService;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 @Service
 public class SendFeedbackMailUseCase {
+	private final QuestionResponseService questionResponseService;
+	private final ResponseFeedbackService responseFeedbackService;
+
 	public void execute() {
-		// TODO: 1. 피드백이 전송되지 않은 문제 List 조회
+		List<QuestionResponse> responses = questionResponseService.list();
+		List<QuestionResponse> feedbackResponses = responses.stream()
+			.filter(response -> !responseFeedbackService.isFeedbackExists(response))
+			.toList();
+
 		// TODO: 2. 피드백이 전송되지 않은 문제에 대해 피드백 메일 전송
 		// TODO: 3. 피드백 메일 처리에 대한 로깅
 	}

--- a/src/main/java/kr/co/csalgo/application/mail/usecase/SendFeedbackMailUseCase.java
+++ b/src/main/java/kr/co/csalgo/application/mail/usecase/SendFeedbackMailUseCase.java
@@ -55,6 +55,6 @@ public class SendFeedbackMailUseCase {
 			}
 		}
 
-		// TODO: 3. 피드백 메일 처리에 대한 로깅
+		log.info("피드백 메일 전송 완료: 성공 {}건, 실패 {}건", successCount, failCount);
 	}
 }

--- a/src/main/java/kr/co/csalgo/common/util/MailTemplate.java
+++ b/src/main/java/kr/co/csalgo/common/util/MailTemplate.java
@@ -4,6 +4,7 @@ public class MailTemplate {
 	public static final String QUESTION_MAIL_SUBJECT = "[CS-ALGO] %s";
 	public static final String VERIFICATION_CODE_SUBJECT = "[CS-ALGO] 이메일 인증 코드";
 	public static final String VERIFICATION_CODE_BODY = "<h3>인증 코드</h3><p>%s</p>";
+	public static final String FEEDBACK_MAIL_SUBJECT = "[CS-ALGO] '%s' 답변에 대한 피드백이 도착했어요!";
 
 	public static String formatVerificationCodeBody(String code) {
 		return VERIFICATION_CODE_BODY.formatted(code);

--- a/src/main/java/kr/co/csalgo/common/util/MailTemplate.java
+++ b/src/main/java/kr/co/csalgo/common/util/MailTemplate.java
@@ -8,4 +8,25 @@ public class MailTemplate {
 	public static String formatVerificationCodeBody(String code) {
 		return VERIFICATION_CODE_BODY.formatted(code);
 	}
+
+	public static String formatFeedbackMailBody(String username, String userAnswer, String modelAnswer) {
+		return """
+			<h2>%s님이 이렇게 말했어요!</h2>
+			<blockquote>%s</blockquote>
+
+			<h2>이런 식으로 답변해보는 건 어떨까요? (by CS-ALGO)</h2>
+			<blockquote>%s</blockquote>
+			""".formatted(username, escapeHtml(userAnswer), escapeHtml(modelAnswer));
+	}
+
+	private static String escapeHtml(String input) {
+		if (input == null) {
+			return "";
+		}
+
+		return input.replace("&", "&amp;")
+			.replace("<", "&lt;")
+			.replace(">", "&gt;")
+			.replace("\"", "&quot;");
+	}
 }

--- a/src/main/java/kr/co/csalgo/config/FeedbackAnalyzerConfig.java
+++ b/src/main/java/kr/co/csalgo/config/FeedbackAnalyzerConfig.java
@@ -1,0 +1,16 @@
+package kr.co.csalgo.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import kr.co.csalgo.domain.question.feedback.FeedbackAnalyzer;
+import kr.co.csalgo.infrastructure.feedback.SimpleFeedbackAnalyzer;
+
+@Configuration
+public class FeedbackAnalyzerConfig {
+	@Bean
+	public FeedbackAnalyzer feedbackAnalyzer() {
+		return new SimpleFeedbackAnalyzer();
+	}
+}
+

--- a/src/main/java/kr/co/csalgo/domain/question/entity/ResponseFeedback.java
+++ b/src/main/java/kr/co/csalgo/domain/question/entity/ResponseFeedback.java
@@ -7,7 +7,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
 import kr.co.csalgo.domain.common.entity.AuditableEntity;
 import lombok.Builder;
 import lombok.Getter;
@@ -19,7 +19,7 @@ import lombok.NoArgsConstructor;
 @SQLDelete(sql = "UPDATE response_feedback SET deleted_at = NOW() WHERE id = ?")
 @SQLRestriction("deleted_at IS NULL")
 public class ResponseFeedback extends AuditableEntity {
-	@ManyToOne(fetch = FetchType.LAZY)
+	@OneToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "response_id", nullable = false)
 	private QuestionResponse response;
 

--- a/src/main/java/kr/co/csalgo/domain/question/feedback/FeedbackAnalyzer.java
+++ b/src/main/java/kr/co/csalgo/domain/question/feedback/FeedbackAnalyzer.java
@@ -1,5 +1,5 @@
 package kr.co.csalgo.domain.question.feedback;
 
 public interface FeedbackAnalyzer {
-	FeedbackResult analyze(String responseContent);
+	FeedbackResult analyze(String responseContent, String questionSolution);
 }

--- a/src/main/java/kr/co/csalgo/domain/question/feedback/FeedbackAnalyzer.java
+++ b/src/main/java/kr/co/csalgo/domain/question/feedback/FeedbackAnalyzer.java
@@ -1,0 +1,5 @@
+package kr.co.csalgo.domain.question.feedback;
+
+public interface FeedbackAnalyzer {
+	FeedbackResult analyze(String responseContent);
+}

--- a/src/main/java/kr/co/csalgo/domain/question/feedback/FeedbackResult.java
+++ b/src/main/java/kr/co/csalgo/domain/question/feedback/FeedbackResult.java
@@ -1,0 +1,17 @@
+package kr.co.csalgo.domain.question.feedback;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class FeedbackResult {
+	private String content;
+
+	@Builder
+	public FeedbackResult(String comment) {
+		this.content = content;
+	}
+}
+

--- a/src/main/java/kr/co/csalgo/domain/question/feedback/FeedbackResult.java
+++ b/src/main/java/kr/co/csalgo/domain/question/feedback/FeedbackResult.java
@@ -7,11 +7,13 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 public class FeedbackResult {
-	private String content;
+	private String responseContent;
+	private String questionSolution;
 
 	@Builder
-	public FeedbackResult(String comment) {
-		this.content = content;
+	public FeedbackResult(String responseContent, String questionSolution) {
+		this.responseContent = responseContent;
+		this.questionSolution = questionSolution;
 	}
 }
 

--- a/src/main/java/kr/co/csalgo/domain/question/repository/ResponseFeedbackRepository.java
+++ b/src/main/java/kr/co/csalgo/domain/question/repository/ResponseFeedbackRepository.java
@@ -1,0 +1,8 @@
+package kr.co.csalgo.domain.question.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import kr.co.csalgo.domain.question.entity.ResponseFeedback;
+
+public interface ResponseFeedbackRepository extends JpaRepository<ResponseFeedback, Long> {
+}

--- a/src/main/java/kr/co/csalgo/domain/question/repository/ResponseFeedbackRepository.java
+++ b/src/main/java/kr/co/csalgo/domain/question/repository/ResponseFeedbackRepository.java
@@ -2,7 +2,9 @@ package kr.co.csalgo.domain.question.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import kr.co.csalgo.domain.question.entity.QuestionResponse;
 import kr.co.csalgo.domain.question.entity.ResponseFeedback;
 
 public interface ResponseFeedbackRepository extends JpaRepository<ResponseFeedback, Long> {
+	boolean existsByResponse(QuestionResponse response);
 }

--- a/src/main/java/kr/co/csalgo/domain/question/service/QuestionResponseService.java
+++ b/src/main/java/kr/co/csalgo/domain/question/service/QuestionResponseService.java
@@ -1,5 +1,7 @@
 package kr.co.csalgo.domain.question.service;
 
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 
 import kr.co.csalgo.domain.question.entity.Question;
@@ -21,5 +23,9 @@ public class QuestionResponseService {
 			.build();
 		questionResponseRepository.save(questionResponse);
 		return questionResponse;
+	}
+
+	public List<QuestionResponse> list() {
+		return questionResponseRepository.findAll();
 	}
 }

--- a/src/main/java/kr/co/csalgo/domain/question/service/ResponseFeedbackService.java
+++ b/src/main/java/kr/co/csalgo/domain/question/service/ResponseFeedbackService.java
@@ -3,6 +3,7 @@ package kr.co.csalgo.domain.question.service;
 import org.springframework.stereotype.Service;
 
 import kr.co.csalgo.domain.question.entity.QuestionResponse;
+import kr.co.csalgo.domain.question.entity.ResponseFeedback;
 import kr.co.csalgo.domain.question.repository.ResponseFeedbackRepository;
 import lombok.RequiredArgsConstructor;
 
@@ -10,6 +11,14 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class ResponseFeedbackService {
 	private final ResponseFeedbackRepository responseFeedbackRepository;
+
+	public ResponseFeedback create(QuestionResponse response, String content) {
+		ResponseFeedback feedback = ResponseFeedback.builder()
+			.response(response)
+			.content(content)
+			.build();
+		return responseFeedbackRepository.save(feedback);
+	}
 
 	public boolean isFeedbackExists(QuestionResponse response) {
 		return responseFeedbackRepository.existsByResponse(response);

--- a/src/main/java/kr/co/csalgo/domain/question/service/ResponseFeedbackService.java
+++ b/src/main/java/kr/co/csalgo/domain/question/service/ResponseFeedbackService.java
@@ -1,0 +1,17 @@
+package kr.co.csalgo.domain.question.service;
+
+import org.springframework.stereotype.Service;
+
+import kr.co.csalgo.domain.question.entity.QuestionResponse;
+import kr.co.csalgo.domain.question.repository.ResponseFeedbackRepository;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ResponseFeedbackService {
+	private final ResponseFeedbackRepository responseFeedbackRepository;
+
+	public boolean isFeedbackExists(QuestionResponse response) {
+		return responseFeedbackRepository.existsByResponse(response);
+	}
+}

--- a/src/main/java/kr/co/csalgo/infrastructure/feedback/SimpleFeedbackAnalyzer.java
+++ b/src/main/java/kr/co/csalgo/infrastructure/feedback/SimpleFeedbackAnalyzer.java
@@ -1,0 +1,17 @@
+package kr.co.csalgo.infrastructure.feedback;
+
+import org.springframework.stereotype.Component;
+
+import kr.co.csalgo.domain.question.feedback.FeedbackAnalyzer;
+import kr.co.csalgo.domain.question.feedback.FeedbackResult;
+
+@Component
+public class SimpleFeedbackAnalyzer implements FeedbackAnalyzer {
+	@Override
+	public FeedbackResult analyze(String responseContent, String questionSolution) {
+		return FeedbackResult.builder()
+			.responseContent(responseContent)
+			.questionSolution(questionSolution)
+			.build();
+	}
+}

--- a/src/main/java/kr/co/csalgo/presentation/scheduler/MailPollingScheduler.java
+++ b/src/main/java/kr/co/csalgo/presentation/scheduler/MailPollingScheduler.java
@@ -5,15 +5,18 @@ import org.springframework.stereotype.Component;
 
 import jakarta.mail.MessagingException;
 import kr.co.csalgo.application.mail.usecase.RegisterQuestionResponseUseCase;
+import kr.co.csalgo.application.mail.usecase.SendFeedbackMailUseCase;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 @Component
 public class MailPollingScheduler {
 	private final RegisterQuestionResponseUseCase registerQuestionResponseUseCase;
+	private final SendFeedbackMailUseCase sendFeedbackMailUseCase;
 
 	@Scheduled(cron = "0 */1 * * * *")
 	public void poll() throws MessagingException {
 		registerQuestionResponseUseCase.execute();
+		sendFeedbackMailUseCase.execute();
 	}
 }

--- a/src/test/java/kr/co/csalgo/domain/question/service/QuestionResponseServiceTest.java
+++ b/src/test/java/kr/co/csalgo/domain/question/service/QuestionResponseServiceTest.java
@@ -38,4 +38,12 @@ public class QuestionResponseServiceTest {
 
 		verify(questionResponseRepository).save(any(QuestionResponse.class));
 	}
+
+	@Test
+	@DisplayName("문제 답변 내역을 조회할 수 있다.")
+	void testListSuccess() {
+		questionResponseService.list();
+
+		verify(questionResponseRepository).findAll();
+	}
 }

--- a/src/test/java/kr/co/csalgo/domain/question/service/ResponseFeedbackServiceTest.java
+++ b/src/test/java/kr/co/csalgo/domain/question/service/ResponseFeedbackServiceTest.java
@@ -1,0 +1,66 @@
+package kr.co.csalgo.domain.question.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import kr.co.csalgo.domain.question.entity.QuestionResponse;
+import kr.co.csalgo.domain.question.entity.ResponseFeedback;
+import kr.co.csalgo.domain.question.repository.ResponseFeedbackRepository;
+
+class ResponseFeedbackServiceTest {
+
+	@Mock
+	private ResponseFeedbackRepository responseFeedbackRepository;
+
+	@InjectMocks
+	private ResponseFeedbackService responseFeedbackService;
+
+	public ResponseFeedbackServiceTest() {
+		MockitoAnnotations.openMocks(this);
+	}
+
+	@Test
+	@DisplayName("피드백이 정상적으로 생성되어 저장된다")
+	void createFeedbackSuccessfully() {
+		// given
+		QuestionResponse response = mock(QuestionResponse.class);
+		String content = "개선 사항입니다.";
+
+		ResponseFeedback expectedFeedback = ResponseFeedback.builder()
+			.response(response)
+			.content(content)
+			.build();
+
+		when(responseFeedbackRepository.save(any())).thenReturn(expectedFeedback);
+
+		// when
+		ResponseFeedback result = responseFeedbackService.create(response, content);
+
+		// then
+		assertThat(result).isNotNull();
+		assertThat(result.getResponse()).isEqualTo(response);
+		assertThat(result.getContent()).isEqualTo(content);
+		verify(responseFeedbackRepository).save(any(ResponseFeedback.class));
+	}
+
+	@Test
+	@DisplayName("피드백 존재 여부를 정확하게 반환한다")
+	void checkIfFeedbackExists() {
+		// given
+		QuestionResponse response = mock(QuestionResponse.class);
+		when(responseFeedbackRepository.existsByResponse(response)).thenReturn(true);
+
+		// when
+		boolean exists = responseFeedbackService.isFeedbackExists(response);
+
+		// then
+		assertThat(exists).isTrue();
+		verify(responseFeedbackRepository).existsByResponse(response);
+	}
+}

--- a/src/test/java/kr/co/csalgo/infrastructure/feedback/SimpleFeedbackAnalyzerTest.java
+++ b/src/test/java/kr/co/csalgo/infrastructure/feedback/SimpleFeedbackAnalyzerTest.java
@@ -1,0 +1,29 @@
+package kr.co.csalgo.infrastructure.feedback;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import kr.co.csalgo.domain.question.feedback.FeedbackResult;
+
+class SimpleFeedbackAnalyzerTest {
+
+	private final SimpleFeedbackAnalyzer analyzer = new SimpleFeedbackAnalyzer();
+
+	@Test
+	@DisplayName("입력된 응답과 정답을 그대로 반환한다")
+	void analyzeReturnsSameContent() {
+		// given
+		String responseContent = "사용자 답변 내용입니다.";
+		String questionSolution = "정답 내용입니다.";
+
+		// when
+		FeedbackResult result = analyzer.analyze(responseContent, questionSolution);
+
+		// then
+		assertThat(result).isNotNull();
+		assertThat(result.getResponseContent()).isEqualTo(responseContent);
+		assertThat(result.getQuestionSolution()).isEqualTo(questionSolution);
+	}
+}

--- a/src/test/java/kr/co/csalgo/presentation/scheduler/MailPollingSchedulerTest.java
+++ b/src/test/java/kr/co/csalgo/presentation/scheduler/MailPollingSchedulerTest.java
@@ -8,15 +8,18 @@ import org.junit.jupiter.api.Test;
 
 import jakarta.mail.MessagingException;
 import kr.co.csalgo.application.mail.usecase.RegisterQuestionResponseUseCase;
+import kr.co.csalgo.application.mail.usecase.SendFeedbackMailUseCase;
 
 class MailPollingSchedulerTest {
 	private RegisterQuestionResponseUseCase registerQuestionResponseUseCase;
+	private SendFeedbackMailUseCase sendFeedbackMailUseCase;
 	private MailPollingScheduler mailPollingScheduler;
 
 	@BeforeEach
 	void setUp() {
 		registerQuestionResponseUseCase = mock(RegisterQuestionResponseUseCase.class);
-		mailPollingScheduler = new MailPollingScheduler(registerQuestionResponseUseCase);
+		sendFeedbackMailUseCase = mock(SendFeedbackMailUseCase.class);
+		mailPollingScheduler = new MailPollingScheduler(registerQuestionResponseUseCase, sendFeedbackMailUseCase);
 	}
 
 	@Test

--- a/src/test/java/kr/co/csalgo/presentation/scheduler/MailPollingSchedulerTest.java
+++ b/src/test/java/kr/co/csalgo/presentation/scheduler/MailPollingSchedulerTest.java
@@ -31,4 +31,14 @@ class MailPollingSchedulerTest {
 		// then
 		verify(registerQuestionResponseUseCase, times(1)).execute();
 	}
+
+	@Test
+	@DisplayName("poll()이 호출되면 SendFeedbackMailUseCase.execute()가 실행되어야 한다")
+	void testPollSendFeedbackMailSuccess() throws MessagingException {
+		// when
+		mailPollingScheduler.poll();
+
+		// then
+		verify(sendFeedbackMailUseCase, times(1)).execute();
+	}
 }


### PR DESCRIPTION
<!-- (title: "[Type] Title close #IssueNumber") -->

## Motivation

<!-- 작성 배경 -->

- resolves #73 

## Problem Solving

<!-- 해결 방법 -->

- `QuestionResponseService`를 통해 수집된 응답 중, 아직 피드백이 존재하지 않는 응답을 필터링하여 피드백 메일을 전송하는 기능을 구현
- `FeedbackAnalyzer`를 통해 응답 내용과 정답을 기반으로 피드백을 생성
- 피드백 메일 전송 후, `ResponseFeedback` 엔티티를 생성하여 중복 전송을 방지하고자 함
- 모든 전송 결과는 성공/실패 건수별로 로깅 처리
- 추후 외부 AI 분석기 연동을 고려해 `FeedbackAnalyzer`를 interface로 추상화하고, 현재는 `SimpleFeedbackAnalyzer`를 기본 구현체로 사용하고자 함

## To Reviewer

<!-- 리뷰어에게 말하고 싶은 것, 유의 깊게 봐주었으면 하는 것, 의문점 등 -->

| Gmail 피드백 UI | 네이버 메일 피드백 UI |
| --- | --- |
| <img width="1023" alt="image" src="https://github.com/user-attachments/assets/e7ef84ff-69ee-4d3a-9a0b-9596ea981d37" /> | <img width="994" alt="image" src="https://github.com/user-attachments/assets/2a451dc0-cf43-4c83-b018-05f6fcee9dcc" /> |

- 현재는 완벽하게 선행 작업 수행 후 피드백 전송을 하기 위해 `MailPollingScheduler.poll()` 호출 시 `registerQuestionResponseUseCase.execute()` 호출(사용자 응답 저장) 후 피드백을 호출하도록 구현했는데, 추후에는 별도의 스케줄러로 관리하면 좋을 것 같습니다.