### PR TITLE
[Fix] deploy.sh 절대 경로로 수정 #78

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -57,6 +57,8 @@ jobs:
         run: |
           aws ssm send-command \
             --document-name "AWS-RunShellScript" \
+            --comment "Deploy cs-algo via GitHub Actions" \
             --instance-ids "${{ secrets.EC2_INSTANCE_ID }}" \
-            --parameters commands='bash ~/cs-algo/deploy.sh' \
+            --region ap-northeast-2 \
+            --parameters commands='bash /home/ssm-user/cs-algo/deploy.sh' \
             --output text


### PR DESCRIPTION
<!-- (title: "[Type] Title close #IssueNumber") -->

## Motivation

<!-- 작성 배경 -->

- resolve #78 

## Problem Solving

<!-- 해결 방법 -->

- PR 
  - #80 
- Systems Manager 명령 기록을 보니 no such file 오류가 발생했으며, 이는 ~가 root 유저의 홈 디렉터리(/root)로 인식된 것이 원인이었습니다.
  - 이에 따라 deploy.sh 내부 경로와 GitHub Actions의 SSM 명령에서 모든 경로를 절대경로(/home/ssm-user/...)로 수정했습니다.
## To Reviewer

<!-- 리뷰어에게 말하고 싶은 것, 유의 깊게 봐주었으면 하는 것, 의문점 등 -->

- 없음
