### PR TITLE
[Feature] Footer의 서비스 피드백 링크 연결 (Google Forms) #89

### DIFF
--- a/src/main/resources/templates/fragments/common/footer.html
+++ b/src/main/resources/templates/fragments/common/footer.html
@@ -7,11 +7,12 @@
             </div>
             <div class="col-md-6 mb-3 text-md-end">
                 <ul class="list-unstyled mb-0">
-                    <li><a href="https://github.com/TEAM-JJINS" class="text-decoration-none text-muted small">팀 소개</a></li>
+                    <li><a href="https://github.com/TEAM-JJINS" class="text-decoration-none text-muted small" target="_blank"
+                           rel="noopener noreferrer">팀 소개</a></li>
                     <li><a href="https://docs.google.com/forms/d/e/1FAIpQLSdOkx5MslyefDvSEf1F5UPI5HBAuwXh70wEqRD9oqzMcJ-8tQ/viewform?usp=header"
-                           class="text-decoration-none text-muted small">서비스 피드백</a></li>
+                           class="text-decoration-none text-muted small" target="_blank" rel="noopener noreferrer">서비스 피드백</a></li>
                     <li><a href="https://github.com/TEAM-JJINS" class="text-decoration-none text-muted small"
-                           target="_blank">GitHub Organization</a></li>
+                           target="_blank" rel="noopener noreferrer">GitHub Organization</a></li>
                 </ul>
             </div>
         </div>


### PR DESCRIPTION
<!-- (title: "[Type] Title close #IssueNumber") -->

## Motivation

<!-- 작성 배경 -->

- resolve #89 

## Problem Solving

<!-- 해결 방법 -->

- [구글 폼 생성 ](https://docs.google.com/forms/d/e/1FAIpQLSdOkx5MslyefDvSEf1F5UPI5HBAuwXh70wEqRD9oqzMcJ-8tQ/viewform?usp=header)
- footer 중 서비스 피드백 버튼에 연결
- 새탭에서 열리도록 `target="_blank"` 설정

## To Reviewer

<!-- 리뷰어에게 말하고 싶은 것, 유의 깊게 봐주었으면 하는 것, 의문점 등 -->
- 구글 폼 문항 중 추가할 것이 있거나, 수정이 필요한 부분은 말씀해주세요!

| footer 클릭 시 google form 이동|
|-|
| ![스크린샷 2025-06-24 191436](https://github.com/user-attachments/assets/dff61bac-b473-4511-9d1c-92c62e6a9652) |
