### PR TITLE
[Feature] 피드백 메일을 원본 메일에 대한 답장으로 처리 #86

### DIFF
--- a/src/main/java/kr/co/csalgo/application/mail/dto/EmailParseResultDto.java
+++ b/src/main/java/kr/co/csalgo/application/mail/dto/EmailParseResultDto.java
@@ -8,11 +8,13 @@ public class EmailParseResultDto {
 	private final String sender;
 	private final String title;
 	private final String response;
+	private final String messageId;
 
 	@Builder
-	public EmailParseResultDto(String sender, String title, String response) {
+	public EmailParseResultDto(String sender, String title, String response, String messageId) {
 		this.sender = sender;
 		this.title = title;
 		this.response = response;
+		this.messageId = messageId;
 	}
 }

--- a/src/main/java/kr/co/csalgo/application/mail/usecase/RegisterQuestionResponseUseCase.java
+++ b/src/main/java/kr/co/csalgo/application/mail/usecase/RegisterQuestionResponseUseCase.java
@@ -44,7 +44,7 @@ public class RegisterQuestionResponseUseCase {
 			log.info("본문 파싱 완료: subject={}, sender={}, response={}", result.getTitle(), result.getSender(), result.getResponse());
 			User user = userService.read(result.getSender());
 			Question question = questionService.read(result.getTitle());
-			QuestionResponse questionResponse = questionResponseService.create(question, user, result.getResponse());
+			QuestionResponse questionResponse = questionResponseService.create(question, user, result.getResponse(), result.getMessageId());
 			log.info("QuestionResponse 저장 완료. questionResponseId={}", questionResponse.getId());
 
 			message.setFlag(Flags.Flag.SEEN, true);

--- a/src/main/java/kr/co/csalgo/application/mail/usecase/SendFeedbackMailUseCase.java
+++ b/src/main/java/kr/co/csalgo/application/mail/usecase/SendFeedbackMailUseCase.java
@@ -40,14 +40,15 @@ public class SendFeedbackMailUseCase {
 
 				ResponseFeedback result = responseFeedbackService.create(response, feedbackResult.getResponseContent());
 
-				emailSender.send(
+				emailSender.sendReply(
 					response.getUser().getEmail(),
-					MailTemplate.FEEDBACK_MAIL_SUBJECT.formatted(response.getQuestion().getTitle()),
+					MailTemplate.FEEDBACK_MAIL_SUBJECT_REPLY.formatted(response.getQuestion().getTitle()),
 					MailTemplate.formatFeedbackMailBody(
 						response.getUser().getEmail().split("@")[0],
 						feedbackResult.getResponseContent(),
 						feedbackResult.getQuestionSolution()
-					));
+					),
+					response.getMessageId());
 				log.info("피드백 메일 전송 성공: responseId={}, feedbackId={}", response.getId(), result.getId());
 				successCount++;
 			} catch (Exception e) {

--- a/src/main/java/kr/co/csalgo/common/util/MailTemplate.java
+++ b/src/main/java/kr/co/csalgo/common/util/MailTemplate.java
@@ -4,7 +4,7 @@ public class MailTemplate {
 	public static final String QUESTION_MAIL_SUBJECT = "[CS-ALGO] %s";
 	public static final String VERIFICATION_CODE_SUBJECT = "[CS-ALGO] 이메일 인증 코드";
 	public static final String VERIFICATION_CODE_BODY = "<h3>인증 코드</h3><p>%s</p>";
-	public static final String FEEDBACK_MAIL_SUBJECT = "[CS-ALGO] '%s' 답변에 대한 피드백이 도착했어요!";
+	public static final String FEEDBACK_MAIL_SUBJECT_REPLY = "Re: [CS-ALGO] %s";
 
 	public static String formatVerificationCodeBody(String code) {
 		return VERIFICATION_CODE_BODY.formatted(code);
@@ -14,7 +14,7 @@ public class MailTemplate {
 		return """
 			<h2>%s님이 이렇게 말했어요!</h2>
 			<blockquote>%s</blockquote>
-
+			<br>
 			<h2>이런 식으로 답변해보는 건 어떨까요? (by CS-ALGO)</h2>
 			<blockquote>%s</blockquote>
 			""".formatted(username, escapeHtml(userAnswer), escapeHtml(modelAnswer));

--- a/src/main/java/kr/co/csalgo/domain/email/EmailSender.java
+++ b/src/main/java/kr/co/csalgo/domain/email/EmailSender.java
@@ -2,4 +2,6 @@ package kr.co.csalgo.domain.email;
 
 public interface EmailSender {
 	void send(String to, String subject, String content);
+
+	void sendReply(String to, String subject, String content, String inReplyTo);
 }

--- a/src/main/java/kr/co/csalgo/domain/email/parser/EmailContentParser.java
+++ b/src/main/java/kr/co/csalgo/domain/email/parser/EmailContentParser.java
@@ -20,13 +20,13 @@ public class EmailContentParser {
 		String title = extractTitle(message);
 		String fullBody = extractTextFromMessage(message);
 		String response = extractResponse(fullBody);
-		String originalMessageId = getOriginalMessageId(message);
+		String messageId = getOriginalMessageId(message);
 
 		return EmailParseResultDto.builder()
 			.sender(sender)
 			.title(title)
 			.response(response)
-			.originalMessageId(originalMessageId)
+			.messageId(messageId)
 			.build();
 	}
 

--- a/src/main/java/kr/co/csalgo/domain/email/parser/EmailContentParser.java
+++ b/src/main/java/kr/co/csalgo/domain/email/parser/EmailContentParser.java
@@ -12,7 +12,7 @@ import kr.co.csalgo.common.exception.ErrorCode;
 public class EmailContentParser {
 
 	public static EmailParseResultDto parse(Message message) {
-		if (message == null || !isReply(message)) {
+		if (message == null || getOriginalMessageId(message) == null) {
 			return null;
 		}
 
@@ -20,11 +20,13 @@ public class EmailContentParser {
 		String title = extractTitle(message);
 		String fullBody = extractTextFromMessage(message);
 		String response = extractResponse(fullBody);
+		String originalMessageId = getOriginalMessageId(message);
 
 		return EmailParseResultDto.builder()
 			.sender(sender)
 			.title(title)
 			.response(response)
+			.originalMessageId(originalMessageId)
 			.build();
 	}
 
@@ -103,12 +105,12 @@ public class EmailContentParser {
 		return fullBody.trim();
 	}
 
-	private static boolean isReply(Message message) {
+	private static String getOriginalMessageId(Message message) {
 		try {
 			String[] inReplyTo = message.getHeader("In-Reply-To");
-			return inReplyTo != null && inReplyTo.length > 0;
+			return inReplyTo != null && inReplyTo.length > 0 ? inReplyTo[0] : null;
 		} catch (Exception e) {
-			return false;
+			return null;
 		}
 	}
 }

--- a/src/main/java/kr/co/csalgo/domain/question/entity/QuestionResponse.java
+++ b/src/main/java/kr/co/csalgo/domain/question/entity/QuestionResponse.java
@@ -33,13 +33,13 @@ public class QuestionResponse extends AuditableEntity {
 	private String content;
 
 	@Column(nullable = false, columnDefinition = "TEXT")
-	private String originalMessageId;
+	private String messageId;
 
 	@Builder
-	public QuestionResponse(Question question, User user, String content, String originalMessageId) {
+	public QuestionResponse(Question question, User user, String content, String messageId) {
 		this.question = question;
 		this.user = user;
 		this.content = content;
-		this.originalMessageId = originalMessageId;
+		this.messageId = messageId;
 	}
 }

--- a/src/main/java/kr/co/csalgo/domain/question/entity/QuestionResponse.java
+++ b/src/main/java/kr/co/csalgo/domain/question/entity/QuestionResponse.java
@@ -32,10 +32,14 @@ public class QuestionResponse extends AuditableEntity {
 	@Column(nullable = false, columnDefinition = "TEXT")
 	private String content;
 
+	@Column(nullable = false, columnDefinition = "TEXT")
+	private String originalMessageId;
+
 	@Builder
-	public QuestionResponse(Question question, User user, String content) {
+	public QuestionResponse(Question question, User user, String content, String originalMessageId) {
 		this.question = question;
 		this.user = user;
 		this.content = content;
+		this.originalMessageId = originalMessageId;
 	}
 }

--- a/src/main/java/kr/co/csalgo/domain/question/service/QuestionResponseService.java
+++ b/src/main/java/kr/co/csalgo/domain/question/service/QuestionResponseService.java
@@ -15,11 +15,12 @@ import lombok.RequiredArgsConstructor;
 public class QuestionResponseService {
 	private final QuestionResponseRepository questionResponseRepository;
 
-	public QuestionResponse create(Question question, User user, String content) {
+	public QuestionResponse create(Question question, User user, String content, String messageId) {
 		QuestionResponse questionResponse = QuestionResponse.builder()
 			.question(question)
 			.user(user)
 			.content(content)
+			.messageId(messageId)
 			.build();
 		questionResponseRepository.save(questionResponse);
 		return questionResponse;

--- a/src/main/java/kr/co/csalgo/infrastructure/email/JavaEmailSender.java
+++ b/src/main/java/kr/co/csalgo/infrastructure/email/JavaEmailSender.java
@@ -15,6 +15,15 @@ public class JavaEmailSender implements EmailSender {
 
 	@Override
 	public void send(String to, String subject, String content) {
+		doSend(to, subject, content, null);
+	}
+
+	@Override
+	public void sendReply(String to, String subject, String content, String originalMessageId) {
+		doSend(to, subject, content, originalMessageId);
+	}
+
+	private void doSend(String to, String subject, String content, String originalMessageId) {
 		try {
 			MimeMessage message = mailSender.createMimeMessage();
 			MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
@@ -23,6 +32,10 @@ public class JavaEmailSender implements EmailSender {
 			helper.setSubject(subject);
 			helper.setText(content, true);
 
+			if (originalMessageId != null) {
+				message.setHeader("In-Reply-To", originalMessageId);
+				message.setHeader("References", originalMessageId);
+			}
 			mailSender.send(message);
 		} catch (Exception e) {
 			throw new CustomBusinessException(ErrorCode.EMAIL_SENDER_ERROR);

--- a/src/test/java/kr/co/csalgo/application/mail/usecase/RegisterQuestionResponseUseCaseTest.java
+++ b/src/test/java/kr/co/csalgo/application/mail/usecase/RegisterQuestionResponseUseCaseTest.java
@@ -50,7 +50,13 @@ public class RegisterQuestionResponseUseCaseTest {
 		Message message = mock(Message.class);
 		when(emailReceiver.receiveMessages()).thenReturn(List.of(message));
 
-		EmailParseResultDto parseResult = new EmailParseResultDto("sender@email.com", "질문제목", "답변내용");
+		EmailParseResultDto parseResult = EmailParseResultDto.builder()
+			.sender("sender@email.com")
+			.title("질문제목")
+			.response("답변내용")
+			.messageId("<original-message-id@example.com>")
+			.build();
+
 		User user = mock(User.class);
 		Question question = mock(Question.class);
 		QuestionResponse response = mock(QuestionResponse.class);
@@ -58,7 +64,7 @@ public class RegisterQuestionResponseUseCaseTest {
 
 		when(userService.read(parseResult.getSender())).thenReturn(user);
 		when(questionService.read(parseResult.getTitle())).thenReturn(question);
-		when(questionResponseService.create(question, user, parseResult.getResponse())).thenReturn(response);
+		when(questionResponseService.create(question, user, parseResult.getResponse(), parseResult.getMessageId())).thenReturn(response);
 
 		try (MockedStatic<EmailContentParser> mockedParser = mockStatic(EmailContentParser.class)) {
 			mockedParser.when(() -> EmailContentParser.parse(message)).thenReturn(parseResult);
@@ -67,7 +73,7 @@ public class RegisterQuestionResponseUseCaseTest {
 
 			verify(userService).read(parseResult.getSender());
 			verify(questionService).read(parseResult.getTitle());
-			verify(questionResponseService).create(question, user, parseResult.getResponse());
+			verify(questionResponseService).create(question, user, parseResult.getResponse(), parseResult.getMessageId());
 			verify(message).setFlag(Flags.Flag.SEEN, true);
 		}
 	}

--- a/src/test/java/kr/co/csalgo/application/mail/usecase/SendFeedbackMailUseCaseTest.java
+++ b/src/test/java/kr/co/csalgo/application/mail/usecase/SendFeedbackMailUseCaseTest.java
@@ -53,6 +53,7 @@ class SendFeedbackMailUseCaseTest {
 
 		QuestionResponse response = QuestionResponse.builder()
 			.question(question)
+			.messageId("<original-message-id@example.com>")
 			.content("제 답변입니다")
 			.user(user)
 			.build();
@@ -74,10 +75,11 @@ class SendFeedbackMailUseCaseTest {
 		sendFeedbackMailUseCase.execute();
 
 		// then
-		verify(emailSender, times(1)).send(
+		verify(emailSender, times(1)).sendReply(
 			eq(user.getEmail()),
-			contains("[CS-ALGO]"),
-			contains("이런 식으로 답변해보는 건 어떨까요?")
+			eq("Re: [CS-ALGO] 트랜잭션"),
+			contains("이런 식으로 답변해보는 건 어떨까요?"),
+			eq("<original-message-id@example.com>")
 		);
 		verify(responseFeedbackService, times(1)).create(response, feedbackResult.getResponseContent());
 	}

--- a/src/test/java/kr/co/csalgo/domain/question/service/QuestionResponseServiceTest.java
+++ b/src/test/java/kr/co/csalgo/domain/question/service/QuestionResponseServiceTest.java
@@ -33,8 +33,9 @@ public class QuestionResponseServiceTest {
 		Question question = Question.builder().title("TDD란?").build();
 		User user = User.builder().email("test@example.com").build();
 		String content = "테스트 주도 개발입니다.";
+		String messageId = "<original-message-id@example.com>";
 
-		questionResponseService.create(question, user, content);
+		questionResponseService.create(question, user, content, messageId);
 
 		verify(questionResponseRepository).save(any(QuestionResponse.class));
 	}

--- a/src/test/java/kr/co/csalgo/infrastructure/email/JavaEmailSenderTest.java
+++ b/src/test/java/kr/co/csalgo/infrastructure/email/JavaEmailSenderTest.java
@@ -38,6 +38,20 @@ class JavaEmailSenderTest {
 	}
 
 	@Test
+	@DisplayName("send - 정상적으로 답장 메일이 전송되어야 한다")
+	void send_shouldSendReplyEmailSuccessfully() throws Exception {
+		// given
+		MimeMessage mimeMessage = mock(MimeMessage.class);
+		when(javaMailSender.createMimeMessage()).thenReturn(mimeMessage);
+
+		// when & then
+		assertThatCode(() -> javaEmailSender.sendReply("test@example.com", "제목", "내용", "<original-message-id@example.com>"))
+			.doesNotThrowAnyException();
+
+		verify(javaMailSender, times(1)).send(mimeMessage);
+	}
+
+	@Test
 	@DisplayName("send - 예외 발생 시 CustomBusinessException이 발생해야 한다")
 	void send_shouldThrowExceptionWhenErrorOccurs() {
 		// given


### PR DESCRIPTION
<!-- (title: "[Type] Title close #IssueNumber") -->

## Motivation

<!-- 작성 배경 -->

- resolve #86 

## Problem Solving

<!-- 해결 방법 -->

- 답장을 보내기 위해선 사용자의 답변 메일의 `messageId`를 알아야함 
  - `QuestionResponse`에 `messageId` 추가 
  -  수신 시 저장
- 피드백 전송 시 In-Reply-To / References 헤더에 수신한 messageId 담아서 처리
- In-Reply-To 헤더 설정해도, 메일 제목이 Re:로 시작하며 원본 제목과 유사해야 클라이언트에서 스레딩(답장)으로 인식함
   - 메일 제목을 `Re: [CS-ALGO] %s` 형태로 변경

## To Reviewer

<!-- 리뷰어에게 말하고 싶은 것, 유의 깊게 봐주었으면 하는 것, 의문점 등 -->
| 메일 헤더 | 구글 메일 | 네이버 메일|
|--|--|--|
| ![스크린샷 2025-06-26 153254](https://github.com/user-attachments/assets/8fbd07d5-7f99-4d4e-bcd9-46b4257ac558) | ![image](https://github.com/user-attachments/assets/a32ed942-6298-4f97-8a8a-c2ca7f4b966e) | ![image](https://github.com/user-attachments/assets/4f2050ce-c6c3-4f1c-811f-6e38c66a2622) |


