### PR TITLE
[Fix] 메일 다크모드 가시성 개선을 위한 이미지 테두리 추가 #117

### DIFF
--- a/src/main/java/kr/co/csalgo/common/util/MailTemplate.java
+++ b/src/main/java/kr/co/csalgo/common/util/MailTemplate.java
@@ -115,7 +115,7 @@ public class MailTemplate {
 	private static String questionTitleSection(String questionTitle) {
 		return """
 			<tr><td style="padding:0 24px;">
-				<img src="%s" width="20" style="vertical-align:middle; margin-right:6px;">
+				<img src="%s" width="20" style="vertical-align:middle; margin-right:6px; border:2px solid #ffffff; border-radius:4px;">
 				<span style="font-size:22px; font-weight:bold;">%s</span>
 			</td></tr>
 			""".formatted(QUESTION_ICON_URL, escapeHtml(questionTitle));
@@ -136,13 +136,13 @@ public class MailTemplate {
 					<tr>
 						<td align="center" style="padding:0 28px;">
 							<a href="https://csalgo-bucket.s3.ap-northeast-2.amazonaws.com/usage/usage.html" target="_blank" style="text-decoration:none;">
-								<img src="%s" width="24" style="display:block; margin-bottom:10px;">
+								<img src="%s" width="24" style="display:block; margin-bottom:10px; border:2px solid #ffffff; border-radius:4px;">
 								<div style="font-size:14px; color:#333;">이용방법</div>
 							</a>
 						</td>
 						<td align="center" style="padding:0 28px;">
 							<a href="https://www.csalgo.co.kr/unsubscription?userId=%s" target="_blank" style="text-decoration:none;">
-								<img src="%s" width="24" style="display:block; margin-bottom:10px;">
+								<img src="%s" width="24" style="display:block; margin-bottom:10px; border:2px solid #ffffff; border-radius:4px;">
 								<div style="font-size:14px; color:#333;">구독 해지</div>
 							</a>
 						</td>
@@ -163,7 +163,7 @@ public class MailTemplate {
 	private static String feedbackQuestionSection(String questionTitle) {
 		return """
 			<tr><td style="padding:24px 24px 0;">
-				<img src="%s" width="20" style="vertical-align:middle; margin-right:6px;">
+				<img src="%s" width="20" style="vertical-align:middle; margin-right:6px; border:2px solid #ffffff; border-radius:4px;">
 				<span style="font-size:18px; font-weight:bold;">CS-ALGO가 질문한 내용이에요!</span>
 			</td></tr>
 			<tr><td style="padding:8px 24px 0; font-size:15px; color:#333; line-height:1.6;">
@@ -175,7 +175,7 @@ public class MailTemplate {
 	private static String feedbackUserAnswerSection(String username, String userAnswer) {
 		return """
 			<tr><td style="padding:32px 24px 0;">
-				<img src="%s" width="20" style="vertical-align:middle; margin-right:6px;">
+				<img src="%s" width="20" style="vertical-align:middle; margin-right:6px; border:2px solid #ffffff; border-radius:4px;">
 				<span style="font-size:18px; font-weight:bold;">%s님이 이렇게 답변했어요!</span>
 			</td></tr>
 			<tr><td style="padding:8px 24px 0; font-size:15px; color:#333; line-height:1.6;">
@@ -187,7 +187,7 @@ public class MailTemplate {
 	private static String feedbackModelAnswerSection(String modelAnswer) {
 		return """
 			<tr><td style="padding:32px 24px 0;">
-				<img src="%s" width="20" style="vertical-align:middle; margin-right:6px;">
+				<img src="%s" width="20" style="vertical-align:middle; margin-right:6px; border:2px solid #ffffff; border-radius:4px;">
 				<span style="font-size:18px; font-weight:bold;">이렇게 답변해보면 어떨까요? (by CS-ALGO)</span>
 			</td></tr>
 			<tr><td style="padding:8px 24px 36px; font-size:15px; color:#333; line-height:1.6;">


### PR DESCRIPTION
<!-- (title: "[Type] Title close #IssueNumber") -->

## Motivation

<!-- 작성 배경 -->

- rosolves #117 

## Problem Solving

<!-- 해결 방법 -->

- 메일 플랫폼의 가시성 개선을 위한 이미지 테두리 추가

## To Reviewer

<!-- 리뷰어에게 말하고 싶은 것, 유의 깊게 봐주었으면 하는 것, 의문점 등 -->

- 이번 PR에서는 이메일 다크모드에서 이미지(로고 및 아이콘)가 배경과 동일하게 반전되어 사라지거나 깨지는 문제를 완화하기 위해, 이미지에 흰색 테두리(`border: 2px solid #ffffff; border-radius:4px`)를 추가했습니다.

- 다만 Gmail의 다크모드는 완전히 #000000 배경이 아니라 **약간 회색(#121212~#222) 계열의 배경을 사용하기 때문에**  테두리가 눈에 띄지 않거나 거의 보이지 않는 경우가 있습니다.  
  이는 Gmail 앱이 자체적으로 다크모드 반전을 수행하면서, CSS `border`를 재해석하거나 색상 대비를 낮게 표시하기 때문입니다.

- 이메일 클라이언트(Gmail, Outlook, Apple Mail 등)는 다크모드에서 HTML/CSS 스타일을 강제로 override하거나 `filter: invert()`를 무시하기 때문에 **완벽하게 대응할 수 있는 표준 방법이 없습니다.**

- 따라서 현재로서는 테두리(white border)로 대비를 확보하는 방법이 가장 현실적인 대안이라고 판단했고, 로고(헤더)는 테두리를 제거하고 아이콘에만 테두리를 적용하여 최소한의 디자인 가독성을 유지하도록 했습니다.

- 혹시 더 나은 이메일 UX 관점에서 아이디어나 개선안 있으시면 편하게 말씀 부탁드립니다.

| 네이버 메일 | Gmail |
| --- | --- |
| ![IMG_7340](https://github.com/user-attachments/assets/a745a0e3-70ba-4362-b464-ae81fcf82ff6) | ![image](https://github.com/user-attachments/assets/174b5d7b-1fe2-405c-a1fc-84fbb388bafb) |