### PR TITLE
[Fix] 인증 코드 메일 전송 시 비동기 실행으로 수정 #112

### DIFF
--- a/src/main/java/kr/co/csalgo/CsAlgoApplication.java
+++ b/src/main/java/kr/co/csalgo/CsAlgoApplication.java
@@ -3,11 +3,13 @@ package kr.co.csalgo;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableJpaAuditing
 @EnableScheduling
 @SpringBootApplication
+@EnableAsync
 public class CsAlgoApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/kr/co/csalgo/infrastructure/email/JavaEmailSender.java
+++ b/src/main/java/kr/co/csalgo/infrastructure/email/JavaEmailSender.java
@@ -2,6 +2,7 @@ package kr.co.csalgo.infrastructure.email;
 
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.scheduling.annotation.Async;
 
 import jakarta.mail.internet.MimeMessage;
 import kr.co.csalgo.common.exception.CustomBusinessException;
@@ -14,6 +15,7 @@ public class JavaEmailSender implements EmailSender {
 	private final JavaMailSender mailSender;
 
 	@Override
+	@Async
 	public void send(String to, String subject, String content) {
 		doSend(to, subject, content, null);
 	}


### PR DESCRIPTION
<!-- (title: "[Type] Title close #IssueNumber") -->

## Motivation

<!-- 작성 배경 -->

- resolve #112 

## Problem Solving

<!-- 해결 방법 -->

- 메일 전송 메서드에 `@Async` 어노테이션 추가
- SpringApplication 클래스에 `@EnableAsync` 어노테이션 추가

## To Reviewer

<!-- 리뷰어에게 말하고 싶은 것, 유의 깊게 봐주었으면 하는 것, 의문점 등 -->

### 고민했던 방법 & 장단점
- **1) `@Async`**
  - 장점: 간단히 어노테이션만으로 비동기 실행 가능, 즉시 적용 가능
  - 단점: 스레드 풀 크기 제한으로 대규모 처리에는 한계, 장애 복원(재시도) 기능 부족
- **2) ApplicationEvent + `@Async`**
  - 장점: 도메인 이벤트 형태로 분리되어 책임이 깔끔, 테스트 용이
  - 단점: 결국 단일 서버 내에서만 작동, MQ로 전환하지 않는 이상 장애 복원 불가
- **3) MQ (RabbitMQ, Kafka 등)**
  - 장점: 완전 비동기 + 재시도 + 모니터링 등 용이, 대규모 서비스에서 표준
  - 단점: 인프라 복잡도 증가, 운영 비용 발생

### 선택 이유
- 현재 트래픽과 서비스 규모상 인증 코드 전송만 비동기화하면 충분해 `@Async`로 우선 적용했습니다.
- 추후 k8s 도입 혹은 트래픽 증가 및 장애 복원 필요 시 MQ 기반 아키텍처로 전환을 고려하면 좋을 것 같습니다.

### 실행 화면

![Jul-08-2025 16-15-28](https://github.com/user-attachments/assets/8f52fb01-1168-4857-a73d-6dcd98d30cb1)