### PR TITLE
[Feature] 네이버 클라우드(NKS) MySQL 서비스 모듈 설정 #162

### DIFF
--- a/csalgo-iac/main.tf
+++ b/csalgo-iac/main.tf
@@ -1,0 +1,7 @@
+module "mysql" {
+  source        = "./modules/mysql"
+  root_password = var.mysql_root_password
+  db_name       = var.mysql_db_name
+  username      = var.mysql_user
+  password      = var.mysql_password
+}

--- a/csalgo-iac/modules/mysql/main.tf
+++ b/csalgo-iac/modules/mysql/main.tf
@@ -1,0 +1,108 @@
+resource "kubernetes_secret" "mysql_env" {
+  metadata {
+    name = "mysql-env"
+  }
+  data = {
+    MYSQL_ROOT_PASSWORD = base64encode(var.root_password)
+    MYSQL_DATABASE      = base64encode(var.db_name)
+    MYSQL_USER          = base64encode(var.username)
+    MYSQL_PASSWORD      = base64encode(var.password)
+  }
+}
+
+resource "kubernetes_deployment" "mysql" {
+  metadata {
+    name = "mysql"
+    labels = {
+      app = "mysql"
+    }
+  }
+
+  spec {
+    replicas = 1
+
+    selector {
+      match_labels = {
+        app = "mysql"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          app = "mysql"
+        }
+      }
+
+      spec {
+        container {
+          name  = "mysql"
+          image = "mysql:8.0"
+
+          port {
+            container_port = 3306
+          }
+
+          env {
+            name = "MYSQL_ROOT_PASSWORD"
+            value_from {
+              secret_key_ref {
+                name = kubernetes_secret.mysql_env.metadata[0].name
+                key  = "MYSQL_ROOT_PASSWORD"
+              }
+            }
+          }
+
+          env {
+            name = "MYSQL_DATABASE"
+            value_from {
+              secret_key_ref {
+                name = kubernetes_secret.mysql_env.metadata[0].name
+                key  = "MYSQL_DATABASE"
+              }
+            }
+          }
+
+          env {
+            name = "MYSQL_USER"
+            value_from {
+              secret_key_ref {
+                name = kubernetes_secret.mysql_env.metadata[0].name
+                key  = "MYSQL_USER"
+              }
+            }
+          }
+
+          env {
+            name = "MYSQL_PASSWORD"
+            value_from {
+              secret_key_ref {
+                name = kubernetes_secret.mysql_env.metadata[0].name
+                key  = "MYSQL_PASSWORD"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+resource "kubernetes_service" "mysql" {
+  metadata {
+    name = "mysql-service"
+  }
+
+  spec {
+    selector = {
+      app = kubernetes_deployment.mysql.metadata[0].labels.app
+    }
+
+    port {
+      port        = 3306
+      target_port = 3306
+    }
+
+    type = "ClusterIP"
+  }
+}

--- a/csalgo-iac/modules/mysql/outputs.tf
+++ b/csalgo-iac/modules/mysql/outputs.tf
@@ -1,0 +1,3 @@
+output "mysql_host" {
+  value = "mysql-service.default.svc.cluster.local"
+}

--- a/csalgo-iac/modules/mysql/variables.tf
+++ b/csalgo-iac/modules/mysql/variables.tf
@@ -1,0 +1,21 @@
+variable "root_password" {
+  description = "MySQL root 계정 비밀번호"
+  type      = string
+  sensitive = true
+}
+
+variable "db_name" {
+  description = "생성할 MySQL 데이터베이스 이름"
+  type = string
+}
+
+variable "username" {
+  description = "MySQL 사용자 이름"
+  type = string
+}
+
+variable "password" {
+  description = "MySQL 사용자 비밀번호"
+  type      = string
+  sensitive = true
+}

--- a/csalgo-iac/variables.tf
+++ b/csalgo-iac/variables.tf
@@ -12,3 +12,25 @@ variable "cluster_name" {
   description = "Naver Cloud Platform NKS 클러스터 이름"
   type        = string
 }
+
+variable "mysql_root_password" {
+  description = "MySQL root 계정 비밀번호"
+  type      = string
+  sensitive = true
+}
+
+variable "mysql_db_name" {
+  description = "생성할 MySQL 데이터베이스 이름"
+  type = string
+}
+
+variable "mysql_user" {
+  description = "MySQL 사용자 이름"
+  type = string
+}
+
+variable "mysql_password" {
+  description = "MySQL 사용자 비밀번호"
+  type      = string
+  sensitive = true
+}


### PR DESCRIPTION
<!-- (title: "[Type] Title close #IssueNumber") -->

## Motivation

<!-- 작성 배경 -->

1. #162

## Problem Solving

<!-- 해결 방법 -->

- mysql 모듈 정의 (aws로 롤백할 경우, 추후 provider 디렉토리 분리하여 관리할 계획)
- mysql 모듈 적용

## To Reviewer

<!-- 리뷰어에게 말하고 싶은 것, 유의 깊게 봐주었으면 하는 것, 의문점 등 -->

### 🖼️ 1. NKS Console 결과

<img width="1920" height="1055" alt="image" src="https://github.com/user-attachments/assets/36077905-c00a-470d-a0e2-7d5211cc7811" />

### ➡️ 2. 루트 모듈에서 MySQL 모듈 호출 흐름

1. `modules/mysql`에 정의된 모듈을 `module "mysql"` 블록으로 불러옵니다.
2. `source` 경로를 통해 상대 위치(`./modules/mysql`)를 참조합니다.
3. `root_password`, `db_name`, `username`, `password`는 루트 모듈의 변수로부터 전달됩니다.
4. 이 값들은 `terraform.tfvars` 또는 GitHub Secret 등 외부에서 주입 가능합니다.
5. 모듈 내부에서는 전달받은 값으로 `Secret`, `Deployment`, `Service` 리소스를 생성합니다.
6. 결과적으로 `mysql-service.default.svc.cluster.local` 주소를 `output`으로 반환합니다.