### PR TITLE
[Chore] sourcecommit push 시 인증방식 수정 #161

### DIFF
--- a/.github/workflows/push-to-sourcecommit.yml
+++ b/.github/workflows/push-to-sourcecommit.yml
@@ -1,4 +1,4 @@
-name: Mirror to SourceCommit
+name: Mirror to SourceCommit via GIT_ASKPASS
 
 on:
   push:
@@ -12,14 +12,21 @@ jobs:
       - name: Checkout GitHub repository
         uses: actions/checkout@v3
         with:
-          fetch-depth: 0  # 전체 Git 히스토리 가져오기
+          fetch-depth: 0  # 전체 히스토리
+
+      - name: Create GIT_ASKPASS script
+        run: |
+          echo 'echo "${{ secrets.NCP_SOURCE_PASSWORD }}"' > askpass.sh
+          chmod +x askpass.sh
 
       - name: Configure Git
         run: |
           git config --global user.name "GitHub Action"
           git config --global user.email "action@github.com"
 
-      - name: Add SourceCommit remote and push
+      - name: Push to SourceCommit using GIT_ASKPASS
+        env:
+          GIT_ASKPASS: ./askpass.sh
         run: |
-          git remote add sourcecommit https://${{ secrets.NCP_SOURCE_USERNAME }}:${{ secrets.NCP_SOURCE_PASSWORD }}@${{ secrets.NCP_SOURCE_URL }}
-          git push -f sourcecommit main  # 🔁 단일 브랜치만 강제 푸시
+          git remote add sourcecommit https://${{ secrets.NCP_SOURCE_USERNAME }}@${{ secrets.NCP_SOURCE_URL }}
+          git push -f sourcecommit main

--- a/.github/workflows/push-to-sourcecommit.yml
+++ b/.github/workflows/push-to-sourcecommit.yml
@@ -3,6 +3,25 @@ name: Mirror to SourceCommit via GIT_ASKPASS
 on:
   push:
     branches: [ "main" ]
+  workflow_dispatch:
+    inputs:
+      logLevel:
+        description: 'Log level'
+        required: true
+        default: 'warning'
+        type: choice
+        options:
+          - info
+          - warning
+          - debug
+      tags:
+        description: 'Test scenario tags'
+        required: false
+        type: boolean
+      environment:
+        description: 'Environment to run tests against'
+        type: environment
+        required: false
 
 jobs:
   mirror:


### PR DESCRIPTION
<!-- (title: "[Type] Title close #IssueNumber") -->

## Motivation

<!-- 작성 배경 -->

- #161 
- 기존 workflow 동작 실패로 인한 버그 해결

## Problem Solving

<!-- 해결 방법 -->

- GIT_ASKPASS를 이용해 자동 입력
  - Git은 내부적으로 username/password 요청 시 GIT_ASKPASS 환경변수를 호출하기 때문에, 아래와 같이 스크립트를 수정하여 해결하였습니다.
    ```sh
    # 1. 임시 비밀번호 반환하는 스크립트 생성
    echo 'echo password' > askpass.sh
    chmod +x askpass.sh
    
    # 2. 환경 변수 설정 후 push
    GIT_ASKPASS=./askpass.sh git push https://username@repository_address
    ```

## To Reviewer

<!-- 리뷰어에게 말하고 싶은 것, 유의 깊게 봐주었으면 하는 것, 의문점 등 -->

### 💻 Local 동작 확인

<img width="1671" height="282" alt="image" src="https://github.com/user-attachments/assets/2966a874-1729-43cd-9076-da696ba29f38" />