### PR TITLE
[Feature] NKS LoadBalancer와 Cloudflare 연동 및 DNS 레코드 구성, HTTPS 적용 #162

### DIFF
--- a/.github/workflows/deploy-nks-terraform.yml
+++ b/.github/workflows/deploy-nks-terraform.yml
@@ -1,8 +1,6 @@
 name: CD - Build & Deploy to NKS (Terraform)
 
 on:
-  pull_request:
-    branches: [ "main" ]
   push:
     branches: [ "main" ]
   workflow_dispatch:

--- a/csalgo-iac/.terraform.lock.hcl
+++ b/csalgo-iac/.terraform.lock.hcl
@@ -1,6 +1,29 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/cloudflare/cloudflare" {
+  version     = "4.4.0"
+  constraints = "4.4.0"
+  hashes = [
+    "h1:KTO2cnNzWChBNGzQ0f00OLIElXBKnmGgIWg+iU9RiLc=",
+    "zh:078da6234c113fcd774ef5e47570a49510d4dc698629a7a17f7cc9c5830595b4",
+    "zh:1b5e7d6129656ab3d8e9f2e65015e4820422e1c54a523a0b039001ce6d5a8f8a",
+    "zh:2554e6551f72b982e23632a5b6cd969675af3e2bc5911d8edcf167d003e772b6",
+    "zh:2709b18364b728e9e5f75c5c15c8a28ece70f625cb09a8a425a00f92c6faf66c",
+    "zh:31d3e477c66f130258709155aca6f32a8974b662ffe181da78d5d608fe327012",
+    "zh:35106d21f181ffc950342be18c3a0acb626eaa27105881272cd54433b54dc3a4",
+    "zh:5915457e5c77e2b5a264a5ca67c0095f507789d063e0698f74fda7444dc01a55",
+    "zh:7df25623d5e7dc9ac8a957c5cfab1134455ce4f997d17f1c26c10e7946b6465b",
+    "zh:890df766e9b839623b1f0437355032a3c006226a6c200cd911e15ee1a9014e9f",
+    "zh:c197e224b86b1c259e2bf7e36705b4e996e5d19da5eef574912714a40308eea8",
+    "zh:c373f64a10a565ab7f4dd229979ab3d75b69ea35afd28bbb3177d3f3f6656a9d",
+    "zh:d44c18831b6a5d359ea49be53abcf5fb3dffeb2e784cf4d3f7c3f445c527a447",
+    "zh:db97e108fd3fd59e8e9bdedc6fef322c754fa3ef25e7e72e8885aad1e257910a",
+    "zh:dbf85dc464b9d884c36c2b96ba7b745e1ea23c356cfe19821ef3d45170d6933a",
+    "zh:e0f315f9c5c04b921c0f3c55f11ff416ec04b6cfce84465cf6e70534bad7c4f2",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/kubernetes" {
   version = "2.38.0"
   hashes = [

--- a/csalgo-iac/main.tf
+++ b/csalgo-iac/main.tf
@@ -46,9 +46,9 @@ module "dns" {
   records = [
     // 루트 도메인 -> 웹 LB IP (A 레코드)
     {
-      name    = ""                           # "" = 루트
-      type    = "A"
-      value   = coalesce(module.web.web_cluster_ip, "")  # IP가 null이면 생성 안 함
+      name    = "@"
+      type    = "CNAME"
+      value   = module.web.web_load_balancer_ip
       ttl     = 3600
       proxied = false
     },
@@ -61,12 +61,12 @@ module "dns" {
       proxied = false
     },
     // api -> 서버 LB IP (A 레코드)
-    {
-      name    = "api"
-      type    = "A"
-      value   = coalesce(module.server.server_cluster_ip, "")
-      ttl     = 3600
-      proxied = false
-    },
+    # {
+    #   name    = "api"
+    #   type    = "A"
+    #   value   = coalesce(module.server.server_cluster_ip, "")
+    #   ttl     = 3600
+    #   proxied = false
+    # },
   ]
 }

--- a/csalgo-iac/main.tf
+++ b/csalgo-iac/main.tf
@@ -36,7 +36,7 @@ module "web" {
 
   image = var.web_image
 
-  external_api_base_url   = module.server.server_load_balancer_hostname
+  external_api_base_url   = "https://api.${var.root_domain}/api"
 }
 
 module "dns" {

--- a/csalgo-iac/modules/dns-cloudflare/main.tf
+++ b/csalgo-iac/modules/dns-cloudflare/main.tf
@@ -15,7 +15,7 @@ resource "cloudflare_record" "this" {
   }
 
   zone_id = var.zone_id
-  name    = each.value.name == "" ? var.root_domain : each.value.name
+  name    = each.value.name == each.value.name
   type    = each.value.type
   value   = each.value.value
   ttl     = each.value.ttl

--- a/csalgo-iac/modules/dns-cloudflare/main.tf
+++ b/csalgo-iac/modules/dns-cloudflare/main.tf
@@ -1,23 +1,33 @@
 terraform {
   required_providers {
     cloudflare = {
-      source  = "cloudflare/cloudflare"       # Cloudflare provider 소스 지정
-      version = "4.4.0"                       # 버전 고정
+      source  = "cloudflare/cloudflare"
+      version = ">= 4.4.0"
     }
   }
 }
 
+locals {
+  # ""와 "@"를 동일하게 취급하도록 정규화
+  norm_records = [
+    for r in var.records : merge(r, {
+      name = (r.name == "" ? "@" : r.name)
+    })
+    if try(r.value, "") != ""
+  ]
+}
+
 resource "cloudflare_record" "this" {
   for_each = {
-    for r in var.records :
-    "${r.type}:${r.name != "" ? r.name : var.root_domain}" => r
-    if r.value != null && r.value != ""
+    for r in local.norm_records :
+    "${r.type}:${r.name}" => r
   }
 
-  zone_id = var.zone_id
-  name    = each.value.name == each.value.name
-  type    = each.value.type
-  value   = each.value.value
-  ttl     = each.value.ttl
-  proxied = each.value.proxied
+  zone_id         = var.zone_id
+  name            = each.value.name                   # ← 문자열로 바로 넣기
+  type            = each.value.type
+  value           = each.value.value
+  ttl             = each.value.ttl
+  proxied         = each.value.proxied
+  allow_overwrite = true                              # ← 기존 레코드 있으면 덮어쓰기
 }

--- a/csalgo-iac/modules/dns-cloudflare/main.tf
+++ b/csalgo-iac/modules/dns-cloudflare/main.tf
@@ -1,0 +1,23 @@
+terraform {
+  required_providers {
+    cloudflare = {
+      source  = "cloudflare/cloudflare"       # Cloudflare provider 소스 지정
+      version = "4.4.0"                       # 버전 고정
+    }
+  }
+}
+
+resource "cloudflare_record" "this" {
+  for_each = {
+    for r in var.records :
+    "${r.type}:${r.name != "" ? r.name : var.root_domain}" => r
+    if r.value != null && r.value != ""
+  }
+
+  zone_id = var.zone_id
+  name    = each.value.name == "" ? var.root_domain : each.value.name
+  type    = each.value.type
+  value   = each.value.value
+  ttl     = each.value.ttl
+  proxied = each.value.proxied
+}

--- a/csalgo-iac/modules/dns-cloudflare/outputs.tf
+++ b/csalgo-iac/modules/dns-cloudflare/outputs.tf
@@ -1,0 +1,4 @@
+output "record_ids" {
+  description = "Cloudflare DNS 레코드 ID 목록"
+  value = { for k, v in cloudflare_record.this : k => v.id }
+}

--- a/csalgo-iac/modules/dns-cloudflare/variables.tf
+++ b/csalgo-iac/modules/dns-cloudflare/variables.tf
@@ -1,0 +1,21 @@
+variable "zone_id" {
+  description = "Cloudflare에서 관리하는 도메인의 Zone ID"
+  type = string
+}
+
+variable "root_domain" {
+  description = "Cloudflare에서 관리하는 루트 도메인"
+  type = string
+}
+
+variable "records" {
+  description = "Cloudflare DNS 레코드 설정"
+  type = list(object({
+    name    : string
+    type    : string         # "A" | "CNAME" | ...
+    value   : string         # IPv4 or hostname
+    ttl     : number
+    proxied : bool
+  }))
+  default = []
+}

--- a/csalgo-iac/modules/server/outputs.tf
+++ b/csalgo-iac/modules/server/outputs.tf
@@ -1,4 +1,5 @@
-output "server_cluster_ip" {
-  description = "Server 클러스터 IP"
-  value = kubernetes_service.csalgo_server.spec[0].cluster_ip
+output "server_load_balancer_hostname" {
+  description = "Server 로드 밸런서 호스트네임"
+  value       = kubernetes_service.csalgo_server.status[0].load_balancer[0].ingress[0].hostname
 }
+

--- a/csalgo-iac/modules/web/main.tf
+++ b/csalgo-iac/modules/web/main.tf
@@ -74,7 +74,7 @@ resource "kubernetes_service" "csalgo_web" {
 
     port {
       port        = 80
-      target_port = 80
+      target_port = 3000
     }
 
     type = "LoadBalancer"

--- a/csalgo-iac/modules/web/outputs.tf
+++ b/csalgo-iac/modules/web/outputs.tf
@@ -1,4 +1,4 @@
-output "web_load_balancer_ip" {
-  description = "Web 로드 밸런서 IP"
+output "web_load_balancer_hostname" {
+  description = "Web 로드 밸런서 호스트네임"
   value       = kubernetes_service.csalgo_web.status[0].load_balancer[0].ingress[0].hostname
 }

--- a/csalgo-iac/modules/web/outputs.tf
+++ b/csalgo-iac/modules/web/outputs.tf
@@ -1,4 +1,4 @@
-output "csalgo_web_url" {
+output "web_cluster_ip" {
   description = "Web 클러스터 IP"
   value       = kubernetes_service.csalgo_web.spec[0].cluster_ip
 }

--- a/csalgo-iac/modules/web/outputs.tf
+++ b/csalgo-iac/modules/web/outputs.tf
@@ -1,4 +1,4 @@
-output "web_cluster_ip" {
-  description = "Web 클러스터 IP"
-  value       = kubernetes_service.csalgo_web.spec[0].cluster_ip
+output "web_load_balancer_ip" {
+  description = "Web 로드 밸런서 IP"
+  value       = kubernetes_service.csalgo_web.status[0].load_balancer[0].ingress[0].hostname
 }

--- a/csalgo-iac/provider.tf
+++ b/csalgo-iac/provider.tf
@@ -4,6 +4,11 @@ terraform {
       source  = "NaverCloudPlatform/ncloud"   # Ncloud provider 소스 지정
       version = "4.0.0"                       # 버전 고정
     }
+
+    cloudflare = {
+      source  = "cloudflare/cloudflare"       # Cloudflare provider 소스 지정
+      version = "5.8.2"                       # 버전 고정
+    }
   }
 
   cloud {
@@ -43,4 +48,8 @@ data "ncloud_nks_cluster" "target" {
 
 provider "kubernetes" {
   config_path = "./kubeconfig.yaml"                             # 선택한 클러스터용 kubeconfig 사용
+}
+
+provider "cloudflare" {
+  api_token = var.cloudflare_api_token
 }

--- a/csalgo-iac/provider.tf
+++ b/csalgo-iac/provider.tf
@@ -7,7 +7,7 @@ terraform {
 
     cloudflare = {
       source  = "cloudflare/cloudflare"       # Cloudflare provider 소스 지정
-      version = "5.8.2"                       # 버전 고정
+      version = "4.4.0"                       # 버전 고정
     }
   }
 

--- a/csalgo-iac/variables.tf
+++ b/csalgo-iac/variables.tf
@@ -78,3 +78,19 @@ variable "web_image" {
   type = string
   default = "csalgo.kr.ncr.ntruss.com/csalgo-web:latest"
 }
+
+variable "cloudflare_api_token" {
+  description = "Cloudflare를 사용하기 위한 API 토큰"
+  type = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare에서 관리하는 도메인의 Zone ID"
+  type = string
+}
+
+variable "root_domain" {
+  description = "Cloudflare에서 관리하는 루트 도메인"
+  type = string
+  default = "csalgo.co.kr"
+}


### PR DESCRIPTION
<!-- (title: "[Type] Title close #IssueNumber") -->

## Motivation

<!-- 작성 배경 -->

- resolve #162 

## Problem Solving

<!-- 해결 방법 -->

1. NKS + Cloudflare 연결: Terraform으로 LB → Cloudflare CNAME 연결, 기존 레코드 충돌 해결
2. 포트 문제: 앱은 3000포트인데 Deployment는 80포트만 열어서 수정하였음
3. LB Hostname 출력: `.status[0].load_balancer[0].ingress[0].hostname`으로 해결
4. HTTPS: Cloudflare Flexible SSL 방식으로 해결

## To Reviewer

<!-- 리뷰어에게 말하고 싶은 것, 유의 깊게 봐주었으면 하는 것, 의문점 등 -->

### 🌏 배포 주소 (Web)

<img width="1920" height="1055" alt="image" src="https://github.com/user-attachments/assets/0c49c19b-3257-4fb4-8e31-b097f6bad79a" />

- 이메일 인증 API 동작 확인하였음
- 링크: [https://www.csalgo.co.kr/](https://www.csalgo.co.kr/)

### ✨ 다음 단계

- 이전 배포 환경에서는 정적 리소스를 AWS S3를 사용하였으나, 이를 삭제하면서 해당 리소스들을 불러올 수 없는 상태임
  - NCP Object Storage 사용 필요

### 📄 참고자료

- [Cloudflare로 https 적용하기](https://usage.tistory.com/199)