### PR TITLE
[Feature] 정적 리소스 호스팅 NCP Object Storage로 이전 #177

### DIFF
--- a/csalgo-common/src/main/java/kr/co/csalgo/common/util/ImageUrlProvider.java
+++ b/csalgo-common/src/main/java/kr/co/csalgo/common/util/ImageUrlProvider.java
@@ -1,0 +1,47 @@
+package kr.co.csalgo.common.util;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ImageUrlProvider {
+
+	private static String imagesBaseUrl;
+	private static String usageUrl;
+
+	public ImageUrlProvider(
+		@Value("${external.resources.images-url}") String imagesBaseUrl,
+		@Value("${external.resources.usage-url}") String usageUrl
+	) {
+		ImageUrlProvider.imagesBaseUrl = imagesBaseUrl;
+		ImageUrlProvider.usageUrl = usageUrl;
+	}
+
+	public static String logo() {
+		return imagesBaseUrl + "/logo.png";
+	}
+
+	public static String questionIcon() {
+		return imagesBaseUrl + "/question.png";
+	}
+
+	public static String responseIcon() {
+		return imagesBaseUrl + "/response.png";
+	}
+
+	public static String solutionIcon() {
+		return imagesBaseUrl + "/solution.png";
+	}
+
+	public static String usageIcon() {
+		return imagesBaseUrl + "/usage.png";
+	}
+
+	public static String unsubscriptionIcon() {
+		return imagesBaseUrl + "/cancel.png";
+	}
+
+	public static String usageUrl() {
+		return usageUrl;
+	}
+}

--- a/csalgo-common/src/main/java/kr/co/csalgo/common/util/MailTemplate.java
+++ b/csalgo-common/src/main/java/kr/co/csalgo/common/util/MailTemplate.java
@@ -9,13 +9,6 @@ public class MailTemplate {
 	public static final String VERIFICATION_CODE_SUBJECT = "[CS-ALGO] 이메일 인증 코드";
 	public static final String FEEDBACK_MAIL_SUBJECT_REPLY = "Re: [CS-ALGO] %s";
 
-	private static final String LOGO_URL = "https://d3cdrqb4y092k4.cloudfront.net/image/logo.png";
-	private static final String QUESTION_ICON_URL = "https://d3cdrqb4y092k4.cloudfront.net/image/question.png";
-	private static final String RESPONSE_ICON_URL = "https://d3cdrqb4y092k4.cloudfront.net/image/response.png";
-	private static final String SOLUTION_ICON_URL = "https://d3cdrqb4y092k4.cloudfront.net/image/solution.png";
-	private static final String USAGE_ICON_URL = "https://d3cdrqb4y092k4.cloudfront.net/image/usage.png";
-	private static final String UNSUBSCRIPTION_ICON_URL = "https://d3cdrqb4y092k4.cloudfront.net/image/cancel.png";
-
 	private static final String PRIMARY_COLOR = "#1c1c1c";
 	private static final String BACKGROUND_COLOR = "#f6f6f6";
 
@@ -86,7 +79,7 @@ public class MailTemplate {
 					<img src="%s" width="100" alt="CS-ALGO" style="display:block;">
 				</a>
 			</td></tr>
-			""".formatted(PRIMARY_COLOR, PRIMARY_COLOR, LOGO_URL);
+			""".formatted(PRIMARY_COLOR, PRIMARY_COLOR, ImageUrlProvider.logo());
 	}
 
 	private static String verificationCodeSection(String code) {
@@ -120,7 +113,7 @@ public class MailTemplate {
 				<img src="%s" width="20" style="vertical-align:middle; margin-right:6px; border:2px solid #ffffff; border-radius:4px;">
 				<span style="font-size:22px; font-weight:bold;">%s</span>
 			</td></tr>
-			""".formatted(QUESTION_ICON_URL, escapeHtml(questionTitle));
+			""".formatted(ImageUrlProvider.questionIcon(), escapeHtml(questionTitle));
 	}
 
 	private static String instructionSection() {
@@ -137,7 +130,7 @@ public class MailTemplate {
 				<table cellpadding="0" cellspacing="0">
 					<tr>
 						<td align="center" style="padding:0 28px;">
-							<a href="https://d3cdrqb4y092k4.cloudfront.net/usage/usage.html" target="_blank" style="text-decoration:none;">
+							<a href="%s" target="_blank" style="text-decoration:none;">
 								<img src="%s" width="24" style="display:block; margin-bottom:10px; border:2px solid #ffffff; border-radius:4px;">
 								<div style="font-size:14px; color:#333;">이용방법</div>
 							</a>
@@ -151,7 +144,7 @@ public class MailTemplate {
 					</tr>
 				</table>
 			</td></tr>
-			""".formatted(USAGE_ICON_URL, userId, UNSUBSCRIPTION_ICON_URL);
+			""".formatted(ImageUrlProvider.usageUrl(), ImageUrlProvider.usageIcon(), userId, ImageUrlProvider.unsubscriptionIcon());
 	}
 
 	private static String footerSection() {
@@ -171,7 +164,7 @@ public class MailTemplate {
 			<tr><td style="padding:8px 24px 0; font-size:15px; color:#333; line-height:1.6;">
 				%s
 			</td></tr>
-			""".formatted(QUESTION_ICON_URL, escapeHtml(questionTitle));
+			""".formatted(ImageUrlProvider.questionIcon(), escapeHtml(questionTitle));
 	}
 
 	private static String feedbackUserAnswerSection(String username, String userAnswer) {
@@ -183,7 +176,7 @@ public class MailTemplate {
 			<tr><td style="padding:8px 24px 0; font-size:15px; color:#333; line-height:1.6;">
 				%s
 			</td></tr>
-			""".formatted(RESPONSE_ICON_URL, escapeHtml(username), escapeHtml(userAnswer));
+			""".formatted(ImageUrlProvider.responseIcon(), escapeHtml(username), escapeHtml(userAnswer));
 	}
 
 	private static String similaritySection(double similarity, String guideMessage) {
@@ -203,7 +196,7 @@ public class MailTemplate {
 			<tr><td style="padding:8px 24px 36px; font-size:15px; color:#333; line-height:1.6;">
 				%s
 			</td></tr>
-			""".formatted(SOLUTION_ICON_URL, escapeHtml(modelAnswer));
+			""".formatted(ImageUrlProvider.solutionIcon(), escapeHtml(modelAnswer));
 	}
 
 	private static String escapeHtml(String input) {

--- a/csalgo-server/src/main/resources/application.yml
+++ b/csalgo-server/src/main/resources/application.yml
@@ -82,3 +82,9 @@ sentry:
   send-default-pii: true
   traces-sample-rate: 1.0
   environment: dev
+
+
+external:
+  resources:
+    usage-url: ${USAGE_GUIDE_URL:https://kr.object.ncloudstorage.com/contest34-bucket-priv/resources/usage.html}
+    images-url: ${IMAGE_BASE_URL:https://kr.object.ncloudstorage.com/contest34-bucket-priv/resources/images}

--- a/csalgo-web/src/main/resources/application.yml
+++ b/csalgo-web/src/main/resources/application.yml
@@ -12,3 +12,4 @@ external:
     base-url: ${EXTERNAL_API_BASE_URL:http://localhost:8080/api}
   resources:
     usage-url: ${USAGE_GUIDE_URL:https://kr.object.ncloudstorage.com/contest34-bucket-priv/resources/usage.html}
+    images-url: ${IMAGE_BASE_URL:https://kr.object.ncloudstorage.com/contest34-bucket-priv/resources/images}

--- a/csalgo-web/src/main/resources/application.yml
+++ b/csalgo-web/src/main/resources/application.yml
@@ -10,3 +10,5 @@ server:
 external:
   api:
     base-url: ${EXTERNAL_API_BASE_URL:http://localhost:8080/api}
+  resources:
+    usage-url: ${USAGE_GUIDE_URL:https://kr.object.ncloudstorage.com/contest34-bucket-priv/resources/usage.html}

--- a/csalgo-web/src/main/resources/templates/fragments/common/navbar.html
+++ b/csalgo-web/src/main/resources/templates/fragments/common/navbar.html
@@ -1,4 +1,4 @@
-<div th:fragment="navbar">
+<div th:fragment="navbar" xmlns:th="http://www.w3.org/1999/xhtml">
     <nav class="navbar navbar-expand-lg fixed-top navbar-dark">
         <div class="container">
             <a class="navbar-brand" href="/">
@@ -11,9 +11,9 @@
             <div class="collapse navbar-collapse flex-grow-0" id="navbarNav">
                 <ul class="navbar-nav mb-2 mb-lg-0">
                     <li class="nav-item"><a class="nav-link" href="#">팀 소개</a></li>
-                    <li class="nav-item"><a class="nav-link" target="_blank" rel="noopener noreferrer"
-                                            href="https://d3cdrqb4y092k4.cloudfront.net/usage/usage.html">이용방법</a>
-                    </li>
+                    <li class="nav-item"><a class="nav-link"
+                                            th:href="@{${@environment.getProperty('external.resources.usage-url')}}"
+                                            target="_blank" rel="noopener noreferrer">이용방법</a></li>
                     <li class="nav-item">
                         <a class="nav-link" href="#" data-bs-toggle="modal" data-bs-target="#subscriptionModal">구독하기</a>
                     </li>


### PR DESCRIPTION
<!-- (title: "[Type] Title close #IssueNumber") -->

## Motivation

<!-- 작성 배경 -->

- resolve #177 

## Problem Solving

<!-- 해결 방법 -->

- NCP Object Storage에 `usage.html` 업로드 후, navbar 및 MailTemplate에서 해당 URL로 경로 수정
- Object Storage 내 `images/` 폴더 생성 및 아이콘·스크린샷 업로드, MailTemplate 이미지 경로 수정
- 모든 URL을 환경변수에 넣고, `ImageUrlProvider`로 URL 관리

## To Reviewer

<!-- 리뷰어에게 말하고 싶은 것, 유의 깊게 봐주었으면 하는 것, 의문점 등 -->

|이용방법 | gmail |  naver |
|--|--|--|
| <img width="1918" height="962" alt="image" src="https://github.com/user-attachments/assets/785b6983-40ad-498e-939d-abb4664dd3ed" /> | <img width="1501" height="694" alt="스크린샷 2025-08-13 232236" src="https://github.com/user-attachments/assets/3bd6e4cf-cb31-4ce9-86c0-02e33cc94996" /> | <img width="1588" height="686" alt="스크린샷 2025-08-13 232142" src="https://github.com/user-attachments/assets/3918a9f9-350a-476d-bb6e-63b97d3cf0ba" /> |

