### PR TITLE
[Feature] 관리자 로그인 API 구현을 위한 사전 작업 #136

### DIFF
--- a/csalgo-application/src/main/java/kr/co/csalgo/application/admin/dto/TokenPair.java
+++ b/csalgo-application/src/main/java/kr/co/csalgo/application/admin/dto/TokenPair.java
@@ -1,0 +1,11 @@
+package kr.co.csalgo.application.admin.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class TokenPair {
+	private String accessToken;
+	private String refreshToken;
+}

--- a/csalgo-application/src/main/java/kr/co/csalgo/application/admin/port/TokenIssuer.java
+++ b/csalgo-application/src/main/java/kr/co/csalgo/application/admin/port/TokenIssuer.java
@@ -1,0 +1,11 @@
+package kr.co.csalgo.application.admin.port;
+
+import kr.co.csalgo.application.admin.dto.TokenPair;
+
+public interface TokenIssuer {
+	String issueAccessToken(String subject, String role);
+
+	TokenPair issueInitialTokens(String subject, String role);
+
+	TokenPair rotate(String refreshToken);
+}

--- a/csalgo-common/src/main/java/kr/co/csalgo/common/exception/ErrorCode.java
+++ b/csalgo-common/src/main/java/kr/co/csalgo/common/exception/ErrorCode.java
@@ -17,6 +17,7 @@ public enum ErrorCode {
 	USER_NOT_FOUND("B001", HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
 	DUPLICATE_EMAIL("B002", HttpStatus.CONFLICT, "이메일이 이미 등록되어 있습니다."),
 	VERIFICATION_CODE_MISMATCH("B003", HttpStatus.BAD_REQUEST, "인증 코드가 일치하지 않습니다."),
+	CREDENTIAL_NOT_FOUND("B004", HttpStatus.NOT_FOUND, "인증 정보를 찾을 수 없습니다."),
 
 	// C: 문제 관련 오류
 	QUESTION_NOT_FOUND("C001", HttpStatus.NOT_FOUND, "문제를 찾을 수 없습니다."),

--- a/csalgo-domain/build.gradle
+++ b/csalgo-domain/build.gradle
@@ -16,6 +16,7 @@ dependencies {
 
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa:3.4.5'
     implementation 'org.springframework.boot:spring-boot-starter-mail:3.4.5'
+    implementation "io.jsonwebtoken:jjwt:0.12.6"
 }
 
 /** ======================

--- a/csalgo-domain/src/main/java/kr/co/csalgo/domain/auth/entity/AuthCredential.java
+++ b/csalgo-domain/src/main/java/kr/co/csalgo/domain/auth/entity/AuthCredential.java
@@ -1,0 +1,42 @@
+package kr.co.csalgo.domain.auth.entity;
+
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import kr.co.csalgo.domain.auth.type.CredentialType;
+import kr.co.csalgo.domain.common.entity.AuditableEntity;
+import kr.co.csalgo.domain.user.entity.User;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE user SET deleted_at = NOW() WHERE id = ?")
+@SQLRestriction("deleted_at IS NULL")
+public class AuthCredential extends AuditableEntity {
+	@ManyToOne(fetch = FetchType.LAZY, optional = false)
+	@JoinColumn(name = "user_id", nullable = false)
+	private User user;
+
+	@Enumerated(EnumType.STRING)
+	private CredentialType type;
+
+	@Column(length = 200)
+	private String passwordHash;
+
+	@Builder
+	public AuthCredential(User user, CredentialType type, String passwordHash) {
+		this.user = user;
+		this.type = type;
+		this.passwordHash = passwordHash;
+	}
+}

--- a/csalgo-domain/src/main/java/kr/co/csalgo/domain/auth/port/PasswordHasher.java
+++ b/csalgo-domain/src/main/java/kr/co/csalgo/domain/auth/port/PasswordHasher.java
@@ -1,0 +1,7 @@
+package kr.co.csalgo.domain.auth.port;
+
+public interface PasswordHasher {
+	String encode(String raw);
+
+	boolean matches(String raw, String encoded);
+}

--- a/csalgo-domain/src/main/java/kr/co/csalgo/domain/auth/port/RefreshTokenStore.java
+++ b/csalgo-domain/src/main/java/kr/co/csalgo/domain/auth/port/RefreshTokenStore.java
@@ -1,0 +1,11 @@
+package kr.co.csalgo.domain.auth.port;
+
+public interface RefreshTokenStore {
+	void initFamily(String familyId, String currentJti, long expiresAtEpochMillis);
+
+	boolean rotateIfLatest(String familyId, String presentedJti, String newJti, long newExpiresAtEpochMillis);
+
+	void revokeFamily(String familyId);
+
+	boolean isFamilyRevoked(String familyId);
+}

--- a/csalgo-domain/src/main/java/kr/co/csalgo/domain/auth/port/TokenCrypto.java
+++ b/csalgo-domain/src/main/java/kr/co/csalgo/domain/auth/port/TokenCrypto.java
@@ -1,0 +1,16 @@
+package kr.co.csalgo.domain.auth.port;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+
+public interface TokenCrypto {
+	String createAccessToken(String subject, String role, String familyId);
+
+	String createAccessToken(String subject, String role);
+
+	String createInitialRefreshToken(String subject, String familyId);
+
+	String createRotatedRefreshToken(String subject, String familyId);
+
+	Jws<Claims> parse(String token);
+}

--- a/csalgo-domain/src/main/java/kr/co/csalgo/domain/auth/repository/AuthCredentialRepository.java
+++ b/csalgo-domain/src/main/java/kr/co/csalgo/domain/auth/repository/AuthCredentialRepository.java
@@ -1,0 +1,12 @@
+package kr.co.csalgo.domain.auth.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import kr.co.csalgo.domain.auth.entity.AuthCredential;
+import kr.co.csalgo.domain.auth.type.CredentialType;
+
+public interface AuthCredentialRepository extends JpaRepository<AuthCredential, Long> {
+	Optional<AuthCredential> findByUserIdAndType(Long userId, CredentialType type);
+}

--- a/csalgo-domain/src/main/java/kr/co/csalgo/domain/auth/service/AuthCredentialService.java
+++ b/csalgo-domain/src/main/java/kr/co/csalgo/domain/auth/service/AuthCredentialService.java
@@ -1,0 +1,27 @@
+package kr.co.csalgo.domain.auth.service;
+
+import org.springframework.stereotype.Service;
+
+import kr.co.csalgo.common.exception.CustomBusinessException;
+import kr.co.csalgo.common.exception.ErrorCode;
+import kr.co.csalgo.domain.auth.entity.AuthCredential;
+import kr.co.csalgo.domain.auth.port.PasswordHasher;
+import kr.co.csalgo.domain.auth.repository.AuthCredentialRepository;
+import kr.co.csalgo.domain.auth.type.CredentialType;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class AuthCredentialService {
+	private final AuthCredentialRepository authCredentialRepository;
+	private final PasswordHasher passwordHasher;
+
+	public AuthCredential read(Long userId, CredentialType type) {
+		return authCredentialRepository.findByUserIdAndType(userId, type)
+			.orElseThrow(() -> new CustomBusinessException(ErrorCode.CREDENTIAL_NOT_FOUND));
+	}
+
+	public boolean matches(String rawPassword, String passwordHash) {
+		return passwordHasher.matches(rawPassword, passwordHash);
+	}
+}

--- a/csalgo-domain/src/main/java/kr/co/csalgo/domain/auth/type/CredentialType.java
+++ b/csalgo-domain/src/main/java/kr/co/csalgo/domain/auth/type/CredentialType.java
@@ -1,0 +1,5 @@
+package kr.co.csalgo.domain.auth.type;
+
+public enum CredentialType {
+	PASSWORD, OAUTH, MAGIC_LINK
+}

--- a/csalgo-domain/src/main/java/kr/co/csalgo/domain/user/entity/User.java
+++ b/csalgo-domain/src/main/java/kr/co/csalgo/domain/user/entity/User.java
@@ -7,7 +7,10 @@ import org.hibernate.annotations.SQLRestriction;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import kr.co.csalgo.domain.common.entity.AuditableEntity;
+import kr.co.csalgo.domain.user.type.Role;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -25,9 +28,14 @@ public class User extends AuditableEntity {
 	@Column(nullable = false, unique = true, columnDefinition = "BINARY(16)")
 	private UUID uuid;
 
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false, length = 20)
+	private Role role;
+
 	@Builder
 	public User(String email) {
 		this.email = email;
 		this.uuid = UUID.randomUUID();
+		this.role = Role.USER;
 	}
 }

--- a/csalgo-domain/src/main/java/kr/co/csalgo/domain/user/entity/User.java
+++ b/csalgo-domain/src/main/java/kr/co/csalgo/domain/user/entity/User.java
@@ -25,9 +25,6 @@ public class User extends AuditableEntity {
 	@Column(nullable = false, unique = true, columnDefinition = "BINARY(16)")
 	private UUID uuid;
 
-	@Column(nullable = true, length = 100)
-	private String password;
-
 	@Builder
 	public User(String email) {
 		this.email = email;

--- a/csalgo-domain/src/main/java/kr/co/csalgo/domain/user/type/Role.java
+++ b/csalgo-domain/src/main/java/kr/co/csalgo/domain/user/type/Role.java
@@ -1,0 +1,5 @@
+package kr.co.csalgo.domain.user.type;
+
+public enum Role {
+	USER, ADMIN
+}

--- a/csalgo-infrastructure/build.gradle
+++ b/csalgo-infrastructure/build.gradle
@@ -26,6 +26,7 @@ dependencies {
     testImplementation 'com.h2database:h2:2.1.214'
     implementation 'com.mysql:mysql-connector-j:9.1.0'
     implementation 'io.sentry:sentry-spring-boot-starter-jakarta:8.12.0'
+    implementation "io.jsonwebtoken:jjwt:0.12.6"
 }
 
 /** ======================

--- a/csalgo-infrastructure/build.gradle
+++ b/csalgo-infrastructure/build.gradle
@@ -17,6 +17,7 @@ dependencies {
 
     implementation 'org.springframework.boot:spring-boot-starter-data-redis:3.4.5'
     implementation 'org.springframework.boot:spring-boot-starter-mail:3.4.5'
+    implementation 'org.springframework.boot:spring-boot-starter-security:3.4.5'
     implementation 'org.apache.lucene:lucene-core:8.11.2'
     implementation 'org.apache.lucene:lucene-analyzers-nori:8.11.2'
     implementation 'net.javacrumbs.shedlock:shedlock-spring:6.3.0'

--- a/csalgo-infrastructure/src/main/java/kr/co/csalgo/infrastructure/auth/repository/RedisRefreshTokenRepository.java
+++ b/csalgo-infrastructure/src/main/java/kr/co/csalgo/infrastructure/auth/repository/RedisRefreshTokenRepository.java
@@ -1,0 +1,79 @@
+package kr.co.csalgo.infrastructure.auth.repository;
+
+import java.time.Duration;
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.dao.DataAccessException;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
+import org.springframework.stereotype.Component;
+
+import kr.co.csalgo.domain.auth.port.RefreshTokenStore;
+import lombok.NonNull;
+
+@Component
+public class RedisRefreshTokenRepository implements RefreshTokenStore {
+	private final StringRedisTemplate redis;
+	private final long defaultTtlMs;
+
+	public RedisRefreshTokenRepository(StringRedisTemplate redis,
+		@Value("${jwt.refresh-ttl-ms:2592000000}") long refreshTtlMs) {
+		this.redis = redis;
+		this.defaultTtlMs = refreshTtlMs;
+	}
+
+	private static String currentKey(String familyId) {
+		return "rt:family:" + familyId + ":current";
+	}
+
+	private static String revokedKey(String familyId) {
+		return "rt:family:" + familyId + ":revoked";
+	}
+
+	@Override
+	public void initFamily(@NonNull String familyId, @NonNull String currentJti, long expMs) {
+		long ttlMs = ttl(expMs);
+		redis.opsForValue().set(currentKey(familyId), currentJti, Duration.ofMillis(ttlMs));
+		redis.delete(revokedKey(familyId));
+	}
+
+	@Override
+	public boolean rotateIfLatest(@NonNull String familyId, @NonNull String presentedJti, @NonNull String newJti, long expMs) {
+		if (redis.hasKey(revokedKey(familyId))) {
+			return false;
+		}
+
+		long ttlMs = ttl(expMs);
+		String script = "local cur = redis.call('GET', KEYS[1]) "
+			+ "if (cur == ARGV[1]) then "
+			+ "  redis.call('SET', KEYS[1], ARGV[2], 'PX', ARGV[3]) "
+			+ "  return 1 else return 0 end";
+		DefaultRedisScript<Long> cas = new DefaultRedisScript<>(script, Long.class);
+		try {
+			Long ok = redis.execute(cas, List.of(currentKey(familyId)), presentedJti, newJti, String.valueOf(ttlMs));
+			return ok == 1L;
+		} catch (DataAccessException e) {
+			return false;
+		}
+	}
+
+	@Override
+	public void revokeFamily(@NonNull String familyId) {
+		redis.opsForValue().set(revokedKey(familyId), "1", Duration.ofMillis(defaultTtlMs));
+		redis.delete(currentKey(familyId));
+	}
+
+	@Override
+	public boolean isFamilyRevoked(@NonNull String familyId) {
+		return redis.hasKey(revokedKey(familyId));
+	}
+
+	private long ttl(long expMs) {
+		if (expMs <= 0) {
+			return defaultTtlMs;
+		}
+		long remain = expMs - System.currentTimeMillis();
+		return remain > 0 ? remain : 1000L;
+	}
+}

--- a/csalgo-infrastructure/src/main/java/kr/co/csalgo/infrastructure/security/BCryptPasswordHasher.java
+++ b/csalgo-infrastructure/src/main/java/kr/co/csalgo/infrastructure/security/BCryptPasswordHasher.java
@@ -1,0 +1,21 @@
+package kr.co.csalgo.infrastructure.security;
+
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Component;
+
+import kr.co.csalgo.domain.auth.port.PasswordHasher;
+
+@Component
+public class BCryptPasswordHasher implements PasswordHasher {
+	private final BCryptPasswordEncoder encoder = new BCryptPasswordEncoder();
+
+	@Override
+	public String encode(String raw) {
+		return encoder.encode(raw);
+	}
+
+	@Override
+	public boolean matches(String raw, String encoded) {
+		return encoder.matches(raw, encoded);
+	}
+}

--- a/csalgo-infrastructure/src/main/java/kr/co/csalgo/infrastructure/security/JwtProvider.java
+++ b/csalgo-infrastructure/src/main/java/kr/co/csalgo/infrastructure/security/JwtProvider.java
@@ -1,0 +1,82 @@
+package kr.co.csalgo.infrastructure.security;
+
+import java.time.Instant;
+import java.util.Date;
+import java.util.UUID;
+
+import javax.crypto.SecretKey;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import kr.co.csalgo.domain.auth.port.TokenCrypto;
+
+@Component
+public class JwtProvider implements TokenCrypto {
+	private final SecretKey key;
+	private final long accessTtlMs;
+	private final long refreshTtlMs;
+
+	public JwtProvider(
+		@Value("${jwt.secret}") String secret,
+		@Value("${jwt.access-ttl-ms:600000}") long accessTtlMs,
+		@Value("${jwt.refresh-ttl-ms:2592000000}") long refreshTtlMs
+	) {
+		this.key = Keys.hmacShaKeyFor(secret.getBytes());
+		this.accessTtlMs = accessTtlMs;
+		this.refreshTtlMs = refreshTtlMs;
+	}
+
+	@Override
+	public String createAccessToken(String subject, String role, String familyId) {
+		Instant now = Instant.now();
+		return Jwts.builder()
+			.setSubject(subject)
+			.claim("role", role)
+			.claim("typ", "access")
+			.claim("family", familyId)
+			.setIssuedAt(Date.from(now))
+			.setExpiration(Date.from(now.plusMillis(accessTtlMs)))
+			.signWith(key, Jwts.SIG.HS256)
+			.compact();
+	}
+
+	@Override
+	public String createAccessToken(String subject, String role) {
+		return createAccessToken(subject, role, null);
+	}
+
+	@Override
+	public String createInitialRefreshToken(String subject, String familyId) {
+		return createRefreshToken(subject, familyId, UUID.randomUUID().toString());
+	}
+
+	@Override
+	public String createRotatedRefreshToken(String subject, String familyId) {
+		return createRefreshToken(subject, familyId, UUID.randomUUID().toString());
+	}
+
+	private String createRefreshToken(String subject, String familyId, String jti) {
+		Instant now = Instant.now();
+		return Jwts.builder()
+			.setSubject(subject)
+			.claim("typ", "refresh")
+			.claim("family", familyId)
+			.setId(jti)
+			.setIssuedAt(Date.from(now))
+			.setExpiration(Date.from(now.plusMillis(refreshTtlMs)))
+			.signWith(key, Jwts.SIG.HS256)
+			.compact();
+	}
+
+	@Override
+	public Jws<Claims> parse(String token) {
+		return Jwts.parser()
+			.verifyWith(key)
+			.build().parseSignedClaims(token);
+	}
+}

--- a/csalgo-infrastructure/src/test/java/kr/co/csalgo/infrastructure/auth/repository/RedisRefreshTokenRepositoryTest.java
+++ b/csalgo-infrastructure/src/test/java/kr/co/csalgo/infrastructure/auth/repository/RedisRefreshTokenRepositoryTest.java
@@ -1,0 +1,103 @@
+package kr.co.csalgo.infrastructure.auth.repository;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+@DisplayName("RedisRefreshTokenRepository 단위 테스트")
+class RedisRefreshTokenRepositoryTest {
+
+	private static LettuceConnectionFactory connectionFactory;
+	private static StringRedisTemplate redisTemplate;
+	private RedisRefreshTokenRepository repository;
+
+	@BeforeAll
+	static void setUpRedis() {
+		// 실제 테스트 환경에서는 Embedded Redis 또는 Testcontainers Redis를 사용할 수 있음
+		connectionFactory = new LettuceConnectionFactory("localhost", 6379);
+		connectionFactory.afterPropertiesSet();
+		redisTemplate = new StringRedisTemplate(connectionFactory);
+	}
+
+	@BeforeEach
+	void setUp() {
+		repository = new RedisRefreshTokenRepository(redisTemplate, 10000L);
+		redisTemplate.getConnectionFactory().getConnection().flushAll();
+	}
+
+	@AfterAll
+	static void tearDown() {
+		if (connectionFactory != null) {
+			connectionFactory.destroy();
+		}
+	}
+
+	@Test
+	@DisplayName("initFamily는 current JTI를 저장하고 revoked 키를 제거한다")
+	void initFamily_storesCurrentAndClearsRevoked() {
+		repository.initFamily("fam1", "jti-123", System.currentTimeMillis() + 5000);
+
+		String cur = redisTemplate.opsForValue().get("rt:family:fam1:current");
+		String revoked = redisTemplate.opsForValue().get("rt:family:fam1:revoked");
+
+		assertThat(cur).isEqualTo("jti-123");
+		assertThat(revoked).isNull();
+	}
+
+	@Test
+	@DisplayName("rotateIfLatest는 현재 JTI와 일치하면 교체하고 true를 반환한다")
+	void rotateIfLatest_success() {
+		String familyId = "fam2";
+		repository.initFamily(familyId, "jti-old", System.currentTimeMillis() + 5000);
+
+		boolean ok = repository.rotateIfLatest(familyId, "jti-old", "jti-new", System.currentTimeMillis() + 5000);
+
+		assertThat(ok).isTrue();
+		String cur = redisTemplate.opsForValue().get("rt:family:" + familyId + ":current");
+		assertThat(cur).isEqualTo("jti-new");
+	}
+
+	@Test
+	@DisplayName("rotateIfLatest는 현재 JTI와 다르면 false를 반환한다")
+	void rotateIfLatest_fail_dueToMismatch() {
+		String familyId = "fam3";
+		repository.initFamily(familyId, "jti-old", System.currentTimeMillis() + 5000);
+
+		boolean ok = repository.rotateIfLatest(familyId, "wrong-jti", "jti-new", System.currentTimeMillis() + 5000);
+
+		assertThat(ok).isFalse();
+		String cur = redisTemplate.opsForValue().get("rt:family:" + familyId + ":current");
+		assertThat(cur).isEqualTo("jti-old");
+	}
+
+	@Test
+	@DisplayName("revokeFamily는 revoked 키를 생성하고 current 키를 제거한다")
+	void revokeFamily_marksRevokedAndDeletesCurrent() {
+		String familyId = "fam4";
+		repository.initFamily(familyId, "jti-xyz", System.currentTimeMillis() + 5000);
+
+		repository.revokeFamily(familyId);
+
+		Boolean revokedExists = redisTemplate.hasKey("rt:family:" + familyId + ":revoked");
+		Boolean currentExists = redisTemplate.hasKey("rt:family:" + familyId + ":current");
+
+		assertThat(revokedExists).isTrue();
+		assertThat(currentExists).isFalse();
+	}
+
+	@Test
+	@DisplayName("isFamilyRevoked는 revoked 키 존재 여부를 반환한다")
+	void isFamilyRevoked_checksKeyExistence() {
+		String familyId = "fam5";
+		assertThat(repository.isFamilyRevoked(familyId)).isFalse();
+
+		repository.revokeFamily(familyId);
+		assertThat(repository.isFamilyRevoked(familyId)).isTrue();
+	}
+}

--- a/csalgo-infrastructure/src/test/java/kr/co/csalgo/infrastructure/security/BCryptPasswordHasherTest.java
+++ b/csalgo-infrastructure/src/test/java/kr/co/csalgo/infrastructure/security/BCryptPasswordHasherTest.java
@@ -1,0 +1,55 @@
+package kr.co.csalgo.infrastructure.security;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("BCryptPasswordHasher 단위 테스트")
+class BCryptPasswordHasherTest {
+
+	private final BCryptPasswordHasher hasher = new BCryptPasswordHasher();
+
+	@Test
+	@DisplayName("encode는 bcrypt 해시를 반환하며 raw와 다르다")
+	void encode_returnsBcryptHash_andNotEqualToRaw() {
+		String raw = "P@ssw0rd!";
+		String encoded = hasher.encode(raw);
+
+		assertThat(encoded).isNotNull();
+		assertThat(encoded).startsWith("$2");
+		assertThat(encoded).isNotEqualTo(raw);
+		assertThat(encoded.length()).isGreaterThanOrEqualTo(60);
+	}
+
+	@Test
+	@DisplayName("matches는 raw와 encoded가 일치할 때 true를 반환한다")
+	void matches_returnsTrue_whenRawMatchesEncoded() {
+		String raw = "my-secret";
+		String encoded = hasher.encode(raw);
+
+		assertThat(hasher.matches(raw, encoded)).isTrue();
+	}
+
+	@Test
+	@DisplayName("matches는 raw와 encoded가 다르면 false를 반환한다")
+	void matches_returnsFalse_whenRawDoesNotMatchEncoded() {
+		String raw = "my-secret";
+		String encoded = hasher.encode(raw);
+
+		assertThat(hasher.matches("other-secret", encoded)).isFalse();
+	}
+
+	@Test
+	@DisplayName("같은 raw를 여러 번 encode하면 서로 다른 해시가 생성된다 (랜덤 솔트)")
+	void encode_sameRawMultipleTimes_producesDifferentHashes_dueToRandomSalt() {
+		String raw = "constant";
+
+		String encoded1 = hasher.encode(raw);
+		String encoded2 = hasher.encode(raw);
+
+		assertThat(encoded1).isNotEqualTo(encoded2); // different salts
+		assertThat(hasher.matches(raw, encoded1)).isTrue();
+		assertThat(hasher.matches(raw, encoded2)).isTrue();
+	}
+}

--- a/csalgo-infrastructure/src/test/java/kr/co/csalgo/infrastructure/security/JwtProviderTest.java
+++ b/csalgo-infrastructure/src/test/java/kr/co/csalgo/infrastructure/security/JwtProviderTest.java
@@ -1,0 +1,86 @@
+package kr.co.csalgo.infrastructure.security;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+
+@DisplayName("JwtProvider 단위 테스트")
+class JwtProviderTest {
+
+	private JwtProvider jwtProvider;
+
+	@BeforeEach
+	void setUp() {
+		// 32바이트 이상 시크릿 필요 (HMAC-SHA256)
+		String secret = "01234567890123456789012345678901";
+		jwtProvider = new JwtProvider(secret, 1000L * 60 * 10, 1000L * 60 * 60 * 24);
+	}
+
+	@Test
+	@DisplayName("AccessToken 생성 시 subject, role, family, typ(access) 클레임이 포함된다")
+	void createAccessToken_containsSubjectRoleAndFamily() {
+		String token = jwtProvider.createAccessToken("user1", "USER", "fam123");
+
+		Jws<Claims> parsed = jwtProvider.parse(token);
+		Claims claims = parsed.getPayload();
+
+		assertThat(claims.getSubject()).isEqualTo("user1");
+		assertThat(claims.get("role", String.class)).isEqualTo("USER");
+		assertThat(claims.get("typ", String.class)).isEqualTo("access");
+		assertThat(claims.get("family", String.class)).isEqualTo("fam123");
+		assertThat(claims.getExpiration()).isAfter(claims.getIssuedAt());
+	}
+
+	@Test
+	@DisplayName("AccessToken 생성 시 familyId가 없으면 family 클레임은 null이다")
+	void createAccessToken_withoutFamilyId_allowsNullFamilyClaim() {
+		String token = jwtProvider.createAccessToken("user2", "ADMIN");
+
+		Jws<Claims> parsed = jwtProvider.parse(token);
+		Claims claims = parsed.getPayload();
+
+		assertThat(claims.getSubject()).isEqualTo("user2");
+		assertThat(claims.get("role", String.class)).isEqualTo("ADMIN");
+		assertThat(claims.get("family")).isNull();
+	}
+
+	@Test
+	@DisplayName("초기 RefreshToken 생성 시 typ(refresh), family, jti 클레임이 포함된다")
+	void createInitialRefreshToken_containsTypRefreshAndFamilyAndJti() {
+		String token = jwtProvider.createInitialRefreshToken("user3", "fam456");
+
+		Jws<Claims> parsed = jwtProvider.parse(token);
+		Claims claims = parsed.getPayload();
+
+		assertThat(claims.getSubject()).isEqualTo("user3");
+		assertThat(claims.get("typ", String.class)).isEqualTo("refresh");
+		assertThat(claims.get("family", String.class)).isEqualTo("fam456");
+		assertThat(claims.getId()).isNotBlank();
+	}
+
+	@Test
+	@DisplayName("회전 RefreshToken은 매번 다른 jti 값을 가진다")
+	void createRotatedRefreshToken_producesDifferentJtiEachTime() {
+		String token1 = jwtProvider.createRotatedRefreshToken("user4", "fam789");
+		String token2 = jwtProvider.createRotatedRefreshToken("user4", "fam789");
+
+		String jti1 = jwtProvider.parse(token1).getPayload().getId();
+		String jti2 = jwtProvider.parse(token2).getPayload().getId();
+
+		assertThat(jti1).isNotEqualTo(jti2);
+	}
+
+	@Test
+	@DisplayName("잘못된 토큰을 파싱하면 예외가 발생한다")
+	void parse_invalidToken_throwsException() {
+		String invalidToken = "invalid.jwt.token";
+
+		assertThatThrownBy(() -> jwtProvider.parse(invalidToken))
+			.isInstanceOf(Exception.class);
+	}
+}

--- a/csalgo-server/src/main/resources/application.yml
+++ b/csalgo-server/src/main/resources/application.yml
@@ -83,6 +83,11 @@ sentry:
   traces-sample-rate: 1.0
   environment: dev
 
+jwt:
+  secret: ${JWT_SECRET}
+  access-ttl-ms: 600000
+  refresh-ttl-ms: 2592000000
+
 
 external:
   resources:


### PR DESCRIPTION
<!-- (title: "[Type] Title close #IssueNumber") -->

## Motivation

<!-- 작성 배경 -->

- #136 

## Problem Solving

<!-- 해결 방법 -->

- `AuthCredential` & `AuthCredentialService` & `Role`
  - `AuthCredential`: 로그인 입력을 담는 도메인 VO (email, password). 형식 검증(공백/이메일 패턴)만 수행.
  - `AuthCredentialService`: 자격 증명 검증 서비스. 관리자 계정 조회 → 비밀번호 대조 → 결과 반환/예외 발생.
  - `Role`: 권한 열거형/상수. 예: ROLE_ADMIN 등. 토큰 클레임과 Security 권한 매핑에 사용.
- `PasswordHasher` & `BCryptPasswordHasher`
  - `PasswordHasher`: 비밀번호 해시/대조 도메인 포트 (encode, matches).
  - `BCryptPasswordHasher`: 스프링 BCryptPasswordEncoder 기반 인프라 어댑터. 비용 인자 조절 가능, 레인보우 테이블 방어에 적합.
- `TokenCrypto` & `JwtProvider`
  - TokenCrypto: 액세스/리프레시 생성·파싱 도메인 포트
    → createAccessToken(subject, role, familyId), createInitialRefreshToken(...), createRotatedRefreshToken(...), parse(token).
  - `JwtProvider`: JJWT 기반 인프라 구현. HS256 서명, AT에 family 클레임 포함(즉시 차단용), RT는 family + jti로 RTR 지원.

## To Reviewer

<!-- 리뷰어에게 말하고 싶은 것, 유의 깊게 봐주었으면 하는 것, 의문점 등 -->

### ❓ 포트-어댑터

- `Port`: 도메인/애플리케이션이 소유한 계약(인터페이스). 규칙과 유스케이스가 의존하는 대상
- `Adapter`: Port를 구현하는 인프라 컴포넌트(JWT/Redis/Email 등). 기술 세부를 캡슐화
- 의존 방향: `application → domain(ports)` / `infrastructure → domain(ports)` (application → infrastructure 금지), 서버에서 DI로 연결하기 위해 사용함
- 장점: 교체 용이(JWT↔다른 구현, Redis 파손 시 대체 등), 테스트 용이(Mock Port), 결합도를 낮출 수 있음
- 우리 구현 포인트:
  - TokenCryptoPort ⇄ JwtTokenProvider
  - RefreshTokenStorePort ⇄ RedisRefreshTokenStore
  - PasswordHasherPort ⇄ BCryptPasswordHasher

### ❓ RTR 방식이란

- Refresh Token Rotation: 리프레시 시 새 RT를 매번 재발급하고, 가장 최신 RT 1개만 유효하게 유지하는 기법.
- 핵심 데이터: familyId(세션 그룹) + jti(RT 식별자). 저장소는 family 당 현재 jti 한 개만 보관.
- 정상 흐름: rotateIfLatest(family, oldJti, newJti)가 원자적(CAS) 으로 교체 → 새 AT/RT 발급.
- 재사용(탈취) 탐지: 제시된 oldJti가 최신이 아니면 실패 → family 전부 revoke(Revoke & Alert 트리거).
- 우리 구현 포인트:
  - Redis+Lua로 CAS 구현(SET PX 교체) → 경쟁 조건 방지.
  - AT에 family 클레임 포함 + 필터에서 isFamilyRevoked 확인 → 즉시 차단.

### ➡️ 다음 작업 사항

- PR의 크기가 너무 커져서 실제 API 구현(`UseCase`와 `Controller` 관련 작업)은 다음 PR에서 분리하려 합니다.