### PR TITLE
[Feature] Jwt 인증 필터 구현을 통한 ROLE 기반 접근 제어 및 @PreAuthorize 적용 #135

### DIFF
--- a/csalgo-common/src/main/java/kr/co/csalgo/common/exception/ErrorCode.java
+++ b/csalgo-common/src/main/java/kr/co/csalgo/common/exception/ErrorCode.java
@@ -22,6 +22,7 @@ public enum ErrorCode {
 	INVALID_TOKEN_TYPE("B006", HttpStatus.BAD_REQUEST, "유효하지 않은 토큰 타입입니다."),
 	REFRESH_FAMILY_REVOKED("B007", HttpStatus.BAD_REQUEST, "리프레시 토큰 패밀리가 취소되었습니다."),
 	REFRESH_TOKEN_REUSE("B008", HttpStatus.BAD_REQUEST, "리프레시 토큰 재사용이 감지되었습니다."),
+	UNAUTHORIZED_ACCESS("B009", HttpStatus.UNAUTHORIZED, "인증되지 않은 접근입니다."),
 
 	// C: 문제 관련 오류
 	QUESTION_NOT_FOUND("C001", HttpStatus.NOT_FOUND, "문제를 찾을 수 없습니다."),

--- a/csalgo-infrastructure/src/main/java/kr/co/csalgo/infrastructure/security/CustomAccessDeniedHandler.java
+++ b/csalgo-infrastructure/src/main/java/kr/co/csalgo/infrastructure/security/CustomAccessDeniedHandler.java
@@ -7,6 +7,8 @@ import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.stereotype.Component;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -21,6 +23,7 @@ public class CustomAccessDeniedHandler implements AccessDeniedHandler {
 	public void handle(HttpServletRequest request,
 		HttpServletResponse response,
 		AccessDeniedException accessDeniedException) throws IOException {
+		objectMapper.registerModule(new JavaTimeModule()).disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
 		response.setStatus(HttpServletResponse.SC_FORBIDDEN);
 		response.setContentType("application/json;charset=UTF-8");
 

--- a/csalgo-infrastructure/src/main/java/kr/co/csalgo/infrastructure/security/CustomAccessDeniedHandler.java
+++ b/csalgo-infrastructure/src/main/java/kr/co/csalgo/infrastructure/security/CustomAccessDeniedHandler.java
@@ -1,0 +1,30 @@
+package kr.co.csalgo.infrastructure.security;
+
+import java.io.IOException;
+
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import kr.co.csalgo.common.exception.ErrorCode;
+import kr.co.csalgo.common.exception.ErrorResponse;
+
+@Component
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+	private final ObjectMapper objectMapper = new ObjectMapper();
+
+	@Override
+	public void handle(HttpServletRequest request,
+		HttpServletResponse response,
+		AccessDeniedException accessDeniedException) throws IOException {
+		response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+		response.setContentType("application/json;charset=UTF-8");
+
+		ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.UNAUTHORIZED_ACCESS);
+		response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+	}
+}

--- a/csalgo-infrastructure/src/main/java/kr/co/csalgo/infrastructure/security/CustomAuthenticationEntryPoint.java
+++ b/csalgo-infrastructure/src/main/java/kr/co/csalgo/infrastructure/security/CustomAuthenticationEntryPoint.java
@@ -7,6 +7,8 @@ import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -21,6 +23,7 @@ public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint 
 	public void commence(HttpServletRequest request,
 		HttpServletResponse response,
 		AuthenticationException authException) throws IOException {
+		objectMapper.registerModule(new JavaTimeModule()).disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
 		response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
 		response.setContentType("application/json;charset=UTF-8");
 

--- a/csalgo-infrastructure/src/main/java/kr/co/csalgo/infrastructure/security/CustomAuthenticationEntryPoint.java
+++ b/csalgo-infrastructure/src/main/java/kr/co/csalgo/infrastructure/security/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,31 @@
+package kr.co.csalgo.infrastructure.security;
+
+import java.io.IOException;
+
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import kr.co.csalgo.common.exception.ErrorCode;
+import kr.co.csalgo.common.exception.ErrorResponse;
+
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+	private final ObjectMapper objectMapper = new ObjectMapper();
+
+	@Override
+	public void commence(HttpServletRequest request,
+		HttpServletResponse response,
+		AuthenticationException authException) throws IOException {
+		response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+		response.setContentType("application/json;charset=UTF-8");
+
+		ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.UNAUTHORIZED_ACCESS);
+		response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+	}
+}
+

--- a/csalgo-infrastructure/src/main/java/kr/co/csalgo/infrastructure/security/JwtAuthenticationFilter.java
+++ b/csalgo-infrastructure/src/main/java/kr/co/csalgo/infrastructure/security/JwtAuthenticationFilter.java
@@ -1,0 +1,29 @@
+package kr.co.csalgo.infrastructure.security;
+
+import java.io.IOException;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+	private final JwtProvider jwtProvider;
+
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws
+		ServletException, IOException {
+		String token = jwtProvider.resolveToken(request);
+		if (token != null && !jwtProvider.validateToken(token)) {
+			Authentication auth = jwtProvider.getAuthentication(token);
+			SecurityContextHolder.getContext().setAuthentication(auth);
+		}
+		filterChain.doFilter(request, response);
+	}
+}

--- a/csalgo-infrastructure/src/main/java/kr/co/csalgo/infrastructure/security/JwtAuthenticationFilter.java
+++ b/csalgo-infrastructure/src/main/java/kr/co/csalgo/infrastructure/security/JwtAuthenticationFilter.java
@@ -20,7 +20,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws
 		ServletException, IOException {
 		String token = jwtProvider.resolveToken(request);
-		if (token != null && !jwtProvider.validateToken(token)) {
+		if (token != null && jwtProvider.validateToken(token)) {
 			Authentication auth = jwtProvider.getAuthentication(token);
 			SecurityContextHolder.getContext().setAuthentication(auth);
 		}

--- a/csalgo-server/build.gradle
+++ b/csalgo-server/build.gradle
@@ -30,6 +30,8 @@ dependencies {
     implementation 'net.javacrumbs.shedlock:shedlock-provider-redis-spring:6.3.0'
     implementation 'com.mysql:mysql-connector-j:9.1.0'
     implementation("io.sentry:sentry-logback:8.12.0")
+
+    testImplementation 'org.springframework.security:spring-security-test'
 }
 
 /** ======================

--- a/csalgo-server/src/main/java/kr/co/csalgo/server/config/SecurityConfig.java
+++ b/csalgo-server/src/main/java/kr/co/csalgo/server/config/SecurityConfig.java
@@ -7,9 +7,13 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
+import kr.co.csalgo.infrastructure.security.CustomAccessDeniedHandler;
+import kr.co.csalgo.infrastructure.security.CustomAuthenticationEntryPoint;
 import kr.co.csalgo.infrastructure.security.JwtAuthenticationFilter;
 import kr.co.csalgo.infrastructure.security.JwtProvider;
 import lombok.RequiredArgsConstructor;
@@ -27,7 +31,8 @@ public class SecurityConfig {
 
 	@SuppressWarnings("squid:S4502")
 	@Bean
-	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+	public SecurityFilterChain filterChain(HttpSecurity http, AuthenticationEntryPoint authenticationEntryPoint,
+		AccessDeniedHandler accessDeniedHandler) throws Exception {
 		return http
 			.csrf(AbstractHttpConfigurer::disable)
 			.authorizeHttpRequests(auth -> auth
@@ -56,6 +61,10 @@ public class SecurityConfig {
 				).permitAll()
 				// 그 외 모든 요청은 인증 필요
 				.anyRequest().authenticated()
+			)
+			.exceptionHandling(ex -> ex
+				.authenticationEntryPoint(new CustomAuthenticationEntryPoint())
+				.accessDeniedHandler(new CustomAccessDeniedHandler())
 			)
 			.addFilterBefore(new JwtAuthenticationFilter(jwtProvider), UsernamePasswordAuthenticationFilter.class)
 			.build();

--- a/csalgo-server/src/main/java/kr/co/csalgo/server/config/SecurityConfig.java
+++ b/csalgo-server/src/main/java/kr/co/csalgo/server/config/SecurityConfig.java
@@ -8,10 +8,17 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import kr.co.csalgo.infrastructure.security.JwtAuthenticationFilter;
+import kr.co.csalgo.infrastructure.security.JwtProvider;
+import lombok.RequiredArgsConstructor;
 
 @Configuration
 @EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
+	private final JwtProvider jwtProvider;
 
 	@Bean
 	public PasswordEncoder passwordEncoder() {
@@ -21,7 +28,36 @@ public class SecurityConfig {
 	@SuppressWarnings("squid:S4502")
 	@Bean
 	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-		http.csrf(AbstractHttpConfigurer::disable);
-		return http.build();
+		return http
+			.csrf(AbstractHttpConfigurer::disable)
+			.authorizeHttpRequests(auth -> auth
+				// Swagger 허용
+				.requestMatchers(
+					"/swagger-ui/**",
+					"/v3/api-docs/**",
+					"/swagger-resources/**",
+					"/webjars/**"
+				).permitAll()
+				// Actuator 허용
+				.requestMatchers(
+					"/actuator/**"
+				).permitAll()
+				// 구독 API 허용
+				.requestMatchers(
+					"/api/subscriptions/**"
+				).permitAll()
+				// 인증 관련 API 허용
+				.requestMatchers(
+					"/api/auth/**"
+				).permitAll()
+				// 관리자 인증 관련 API 허용
+				.requestMatchers(
+					"/api/admin/**"
+				).permitAll()
+				// 그 외 모든 요청은 인증 필요
+				.anyRequest().authenticated()
+			)
+			.addFilterBefore(new JwtAuthenticationFilter(jwtProvider), UsernamePasswordAuthenticationFilter.class)
+			.build();
 	}
 }

--- a/csalgo-server/src/main/java/kr/co/csalgo/server/question/QuestionController.java
+++ b/csalgo-server/src/main/java/kr/co/csalgo/server/question/QuestionController.java
@@ -2,6 +2,7 @@ package kr.co.csalgo.server.question;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -34,6 +35,7 @@ public class QuestionController {
 	private final DeleteQuestionUseCase deleteQuestionUseCase;
 
 	@PostMapping("/{questionId}/send")
+	@PreAuthorize("hasRole('ROLE_ADMIN')")
 	@Operation(summary = "문제 메일 전송", description = "사용자가 문제를 확인할 수 있도록 메일을 전송합니다.")
 	@ApiResponse(responseCode = "200", description = "메일 전송 성공")
 	@ApiResponse(responseCode = "400", description = "잘못된 요청 (유효성 검사 실패 등)")
@@ -48,6 +50,7 @@ public class QuestionController {
 	}
 
 	@GetMapping("")
+	@PreAuthorize("hasRole('ROLE_ADMIN')")
 	@Operation(summary = "문제 목록 조회", description = "관리자는 문제 목록을 조회할 수 있습니다.")
 	@ApiResponse(responseCode = "200", description = "문제 목록 조회 성공")
 	public ResponseEntity<?> getQuestionList(
@@ -58,6 +61,7 @@ public class QuestionController {
 	}
 
 	@GetMapping("/{questionId}")
+	@PreAuthorize("hasRole('ROLE_ADMIN')")
 	@Operation(summary = "문제 상세 조회", description = "관리자는 문제 상세정보를 조회할 수 있습니다.")
 	@ApiResponse(responseCode = "200", description = "문제 상세 조회 성공")
 	public ResponseEntity<?> getQuestionDetail(@PathVariable Long questionId) {
@@ -65,6 +69,7 @@ public class QuestionController {
 	}
 
 	@PutMapping("/{questionId}")
+	@PreAuthorize("hasRole('ROLE_ADMIN')")
 	@Operation(summary = "문제 수정", description = "관리자는 문제를 수정할 수 있습니다.")
 	@ApiResponse(responseCode = "200", description = "문제 수정 성공")
 	public ResponseEntity<?> questionUpdate(@PathVariable Long questionId, @RequestBody QuestionDto.Request request) {
@@ -73,6 +78,7 @@ public class QuestionController {
 	}
 
 	@DeleteMapping("/{questionId}")
+	@PreAuthorize("hasRole('ROLE_ADMIN')")
 	@Operation(summary = "문제 삭제", description = "관리자는 문제를 삭제할 수 있습니다.")
 	@ApiResponse(responseCode = "200", description = "문제 삭제 성공")
 	public ResponseEntity<?> questionDelete(@PathVariable Long questionId) {

--- a/csalgo-server/src/main/java/kr/co/csalgo/server/user/UserController.java
+++ b/csalgo-server/src/main/java/kr/co/csalgo/server/user/UserController.java
@@ -1,6 +1,7 @@
 package kr.co.csalgo.server.user;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -23,6 +24,7 @@ public class UserController {
 	private final DeleteUserUseCase deleteUserUseCase;
 
 	@GetMapping("")
+	@PreAuthorize("hasRole('ROLE_ADMIN')")
 	@Operation(summary = "사용자 목록 조회", description = "관리자는 사용자 목록을 조회할 수 있습니다.")
 	@ApiResponse(responseCode = "200", description = "사용자 목록 조회 성공")
 	public ResponseEntity<?> getUserList(
@@ -33,6 +35,7 @@ public class UserController {
 	}
 
 	@GetMapping("/{userId}")
+	@PreAuthorize("hasRole('ROLE_ADMIN')")
 	@Operation(summary = "사용자 상세 조회", description = "관리자는 사용자 정보를 조회할 수 있습니다.")
 	@ApiResponse(responseCode = "200", description = "사용자 상세 조회 성공")
 	public ResponseEntity<?> getUserDetail(@PathVariable Long userId) {
@@ -40,6 +43,7 @@ public class UserController {
 	}
 
 	@DeleteMapping("/{userId}")
+	@PreAuthorize("hasRole('ROLE_ADMIN')")
 	@Operation(summary = "사용자 삭제", description = "관리자는 사용자 정보를 삭제 할 수 있습니다.")
 	@ApiResponse(responseCode = "200", description = "사용자 삭제 성공")
 	public ResponseEntity<?> deleteUser(@PathVariable Long userId) {

--- a/csalgo-server/src/test/java/kr/co/csalgo/server/question/QuestionControllerTest.java
+++ b/csalgo-server/src/test/java/kr/co/csalgo/server/question/QuestionControllerTest.java
@@ -15,6 +15,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
@@ -35,6 +36,7 @@ import kr.co.csalgo.common.message.MessageCode;
 @SpringBootTest
 @AutoConfigureMockMvc
 @Transactional
+@WithMockUser(username = "admin@csalgo.co.kr", roles = {"ADMIN"})
 class QuestionControllerTest {
 
 	@Autowired

--- a/csalgo-server/src/test/java/kr/co/csalgo/server/user/UserControllerTest.java
+++ b/csalgo-server/src/test/java/kr/co/csalgo/server/user/UserControllerTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
@@ -27,6 +28,7 @@ import kr.co.csalgo.common.message.MessageCode;
 @SpringBootTest
 @AutoConfigureMockMvc
 @Transactional
+@WithMockUser(username = "admin@csalgo.co.kr", roles = {"ADMIN"})
 class UserControllerTest {
 	@Autowired
 	private MockMvc mockMvc;


### PR DESCRIPTION
<!-- (title: "[Type] Title close #IssueNumber") -->

## Motivation

<!-- 작성 배경 -->

- resolve #135 

## Problem Solving

<!-- 해결 방법 -->

- Spring Security 기반 인증/인가 로직 적용
- `SecurityConfig`에 JWT 필터(`JwtAuthenticationFilter`) 등록 및 Swagger/Actuator 등 특정 경로 허용
- `JwtProvider`에 `resolveToken`, `validateToken`, `getAuthentication` 메서드 추가 → 토큰 기반 사용자 인증 구현
- `CustomAuthenticationEntryPoint`, `CustomAccessDeniedHandler` 구현 및 `SecurityConfig`에 등록 → 인증/인가 실패 시 JSON `ErrorResponse` 반환
- 테스트 환경에서 `spring-security-test` 의존성 추가 및 `@WithMockUser` 활용하여 ROLE 기반 접근 제어 검증

## To Reviewer

<!-- 리뷰어에게 말하고 싶은 것, 유의 깊게 봐주었으면 하는 것, 의문점 등 -->

### 📝 블로그 포스트

- `JwtAuthenticationFilter` 동작 과정, `@PreAuthorize` 권한 검증 흐름, `SecurityContext` 저장 방식에 대한 상세 다이어그램과 설명은 제 개인 블로그에 별도 정리하였습니다. 한 번 읽어보시면 좋을 것 같아요!
- 👉 [Spring Security + JWT 기반 인증/인가 구현기](https://jinlee.kr/web/2025-08-18-spring-security-jwt-authentication/)

### 🏃 Postman

<img width="513" height="658" alt="image" src="https://github.com/user-attachments/assets/01adbd37-b33a-490a-98b7-911b56526ef5" />