### PR TITLE
[Fix] NKS의 Web Deployment에 jwt_secret 환경변수 추가 #187

### DIFF
--- a/csalgo-iac/main.tf
+++ b/csalgo-iac/main.tf
@@ -38,6 +38,7 @@ module "web" {
   image = var.web_image
 
   external_api_base_url   = "https://api.${var.root_domain}/api"
+  jwt_secret              = var.jwt_secret
 }
 
 module "dns" {

--- a/csalgo-iac/modules/web/main.tf
+++ b/csalgo-iac/modules/web/main.tf
@@ -5,6 +5,7 @@ resource "kubernetes_secret" "csalgo_web_env" {
 
   data = {
     EXTERNAL_API_BASE_URL = var.external_api_base_url
+    JWT_SECRET            = var.jwt_secret
   }
 
   type = "Opaque"
@@ -53,6 +54,16 @@ resource "kubernetes_deployment" "csalgo_web" {
               secret_key_ref {
                 name = kubernetes_secret.csalgo_web_env.metadata[0].name
                 key  = "EXTERNAL_API_BASE_URL"
+              }
+            }
+          }
+
+          env {
+            name  = "JWT_SECRET"
+            value_from {
+              secret_key_ref {
+                name = kubernetes_secret.csalgo_web_env.metadata[0].name
+                key  = "JWT_SECRET"
               }
             }
           }

--- a/csalgo-iac/modules/web/variables.tf
+++ b/csalgo-iac/modules/web/variables.tf
@@ -7,3 +7,9 @@ variable "external_api_base_url" {
   description = "API 호출을 위한 외부 API의 기본 URL"
   type        = string
 }
+
+variable "jwt_secret" {
+  description = "JWT Secret Key"
+  type        = string
+  sensitive   = true
+}


### PR DESCRIPTION
<!-- (title: "[Type] Title close #IssueNumber") -->

## Motivation

<!-- 작성 배경 -->

- resolve #187 

## Problem Solving

<!-- 해결 방법 -->

- 기존에 누락된 Web Deployment의 환경변수(`jwt_secret`) 추가 시 정상 동작

## To Reviewer

<!-- 리뷰어에게 말하고 싶은 것, 유의 깊게 봐주었으면 하는 것, 의문점 등 -->

### 📜 Error logs

```
Caused by: io.jsonwebtoken.security.WeakKeyException: The specified key byte array is 48 bits which is not secure enough for any JWT HMAC-SHA algorithm.  The JWT JWA Specification (RFC 7518, Section 3.2) states that keys used with HMAC-SHA algorithms MUST have a size >= 256 bits (the key size must be greater than or equal to the hash output size).  Consider using the Jwts.SIG.HS256.key() builder (or HS384.key() or HS512.key()) to create a key guaranteed to be secure enough for your preferred HMAC-SHA algorithm.  See https://tools.ietf.org/html/rfc7518#section-3.2 for more information.
 at io.jsonwebtoken.security.Keys.hmacShaKeyFor(Keys.java:83) ~[jjwt-api-0.12.6.jar!/:0.12.6]
 at kr.co.csalgo.web.security.JwtValidator.<init>(JwtValidator.java:23) ~[!/:1.0.0-SNAPSHOT]
 at java.base/jdk.internal.reflect.DirectConstructorHandleAccessor.newInstance(DirectConstructorHandleAccessor.java:62) ~[na:na]
 at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:502) ~[na:na]
 at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:486) ~[na:na]
 at org.springframework.beans.BeanUtils.instantiateClass(BeanUtils.java:209) ~[spring-beans-6.2.6.jar!/:6.2.6]
```

- 위 로그를 통해 환경 변수가 올바르게 주입되지 않고 있다는 것을 파악할 수 있었습니다.

### 🖼️ 서비스 정상 동작 확인

| NKS Console | 서비스 주소 접속 |
| --- | --- |
| <img width="1920" height="1055" alt="image" src="https://github.com/user-attachments/assets/8337cc3d-5734-4e09-ac65-5171f2490b88" /> | <img width="1920" height="1055" alt="image" src="https://github.com/user-attachments/assets/b7ccf5b6-f8ad-4230-84ed-a1bf10ac98ed" /> |

- `520 Error`란? : 앱이 “정상 기동하지 못해(origin이 제대로 응답을 못해)” Cloudflare가 520(Unknown Error at origin) 오류를 출력

### 🔄 원인 연쇄 작용

1. 잘못된 환경변수(짧은 HMAC 키 혹은 키 누락)
2. Spring 부팅 실패(WeakKeyException)
3. 컨테이너 Ready/Liveness 실패
4. Ingress 업스트림에 “정상 엔드포인트 없음/연결 중단”
5. Cloudflare가 원본으로부터 정상 HTTP 헤더를 못 받음/연결이 비정상 종료
6. 520 Host Error 표출.