### PR TITLE
[Fix] 관리자 대시보드용 API의 페이지네이션 동작 수정 #131, #133

### DIFF
--- a/csalgo-application/src/main/java/kr/co/csalgo/application/common/dto/PagedResponse.java
+++ b/csalgo-application/src/main/java/kr/co/csalgo/application/common/dto/PagedResponse.java
@@ -1,0 +1,28 @@
+package kr.co.csalgo.application.common.dto;
+
+import java.util.List;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class PagedResponse<T> {
+	private List<T> content;
+	private int currentPage;
+	private int totalPages;
+	private long totalElements;
+	private boolean first;
+	private boolean last;
+
+	@Builder
+	public PagedResponse(List<T> content, int currentPage, int totalPages, long totalElements, boolean first, boolean last) {
+		this.content = content;
+		this.currentPage = currentPage;
+		this.totalPages = totalPages;
+		this.totalElements = totalElements;
+		this.first = first;
+		this.last = last;
+	}
+}

--- a/csalgo-application/src/main/java/kr/co/csalgo/application/problem/dto/QuestionDto.java
+++ b/csalgo-application/src/main/java/kr/co/csalgo/application/problem/dto/QuestionDto.java
@@ -1,5 +1,7 @@
 package kr.co.csalgo.application.problem.dto;
 
+import java.time.LocalDateTime;
+
 import kr.co.csalgo.domain.question.entity.Question;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -14,30 +16,44 @@ public class QuestionDto {
 	@NoArgsConstructor
 	public static class Request {
 		private String title;
+		private String description;
 		private String solution;
 
 		@Builder
-		public Request(String title, String solution) {
+		public Request(String title, String description, String solution) {
 			this.title = title;
+			this.description = description;
 			this.solution = solution;
 		}
 	}
 
 	@Getter
 	public static class Response {
+		private Long id;
 		private String title;
+		private String description;
 		private String solution;
+		private LocalDateTime createdAt;
+		private LocalDateTime updatedAt;
 
 		@Builder
-		public Response(String title, String solution) {
+		public Response(Long id, String title, String description, String solution, LocalDateTime createdAt, LocalDateTime updatedAt) {
+			this.id = id;
 			this.title = title;
+			this.description = description;
 			this.solution = solution;
+			this.createdAt = createdAt;
+			this.updatedAt = updatedAt;
 		}
 
 		public static Response of(Question question) {
 			return Response.builder()
+				.id(question.getId())
 				.title(question.getTitle())
+				.description(question.getDescription())
 				.solution(question.getSolution())
+				.createdAt(question.getCreatedAt())
+				.updatedAt(question.getUpdatedAt())
 				.build();
 		}
 	}

--- a/csalgo-application/src/main/java/kr/co/csalgo/application/problem/usecase/GetQuestionUseCase.java
+++ b/csalgo-application/src/main/java/kr/co/csalgo/application/problem/usecase/GetQuestionUseCase.java
@@ -2,9 +2,14 @@ package kr.co.csalgo.application.problem.usecase;
 
 import java.util.List;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
+import kr.co.csalgo.application.common.dto.PagedResponse;
 import kr.co.csalgo.application.problem.dto.QuestionDto;
+import kr.co.csalgo.domain.question.entity.Question;
 import kr.co.csalgo.domain.question.service.QuestionService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -15,13 +20,25 @@ import lombok.extern.slf4j.Slf4j;
 public class GetQuestionUseCase {
 	private final QuestionService questionService;
 
-	public List<QuestionDto.Response> getQuestionListWithPaging(int page, int size) {
-		List<QuestionDto.Response> questions = questionService.list(page - 1, size).stream()
+	public PagedResponse<QuestionDto.Response> getQuestionListWithPaging(int page, int size) {
+		Pageable pageable = PageRequest.of(page - 1, size);
+		Page<Question> questionPage = questionService.list(pageable);
+
+		List<QuestionDto.Response> questions = questionPage.getContent().stream()
 			.map(QuestionDto.Response::of)
 			.toList();
-		log.info("[문제 리스트 조회 완료] count:{}", questions.size());
-		return questions;
 
+		log.info("[문제 리스트 조회 완료] count:{}, page:{}/{}",
+			questions.size(), page, questionPage.getTotalPages());
+
+		return PagedResponse.<QuestionDto.Response>builder()
+			.content(questions)
+			.currentPage(page)
+			.totalPages(questionPage.getTotalPages())
+			.totalElements(questionPage.getTotalElements())
+			.first(questionPage.isFirst())
+			.last(questionPage.isLast())
+			.build();
 	}
 
 	public QuestionDto.Response getQuestionDetail(Long questionId) {

--- a/csalgo-application/src/main/java/kr/co/csalgo/application/user/dto/UserDto.java
+++ b/csalgo-application/src/main/java/kr/co/csalgo/application/user/dto/UserDto.java
@@ -1,8 +1,10 @@
 package kr.co.csalgo.application.user.dto;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 import kr.co.csalgo.domain.user.entity.User;
+import kr.co.csalgo.domain.user.type.Role;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -12,19 +14,31 @@ import lombok.NoArgsConstructor;
 public class UserDto {
 	@Getter
 	public static class Response {
+		private Long id;
 		private String email;
+		private Role role;
 		private UUID uuid;
+		private LocalDateTime createdAt;
+		private LocalDateTime updatedAt;
 
 		@Builder
-		public Response(String email, UUID uuid) {
+		public Response(Long id, String email, Role role, UUID uuid, LocalDateTime createdAt, LocalDateTime updatedAt) {
+			this.id = id;
 			this.email = email;
+			this.role = role;
 			this.uuid = uuid;
+			this.createdAt = createdAt;
+			this.updatedAt = updatedAt;
 		}
 
 		public static UserDto.Response of(User user) {
 			return UserDto.Response.builder()
+				.id(user.getId())
 				.email(user.getEmail())
+				.role(user.getRole())
 				.uuid(user.getUuid())
+				.createdAt(user.getCreatedAt())
+				.updatedAt(user.getUpdatedAt())
 				.build();
 		}
 	}

--- a/csalgo-application/src/test/java/kr/co/csalgo/application/user/usecase/GetUserUseCaseTest.java
+++ b/csalgo-application/src/test/java/kr/co/csalgo/application/user/usecase/GetUserUseCaseTest.java
@@ -11,7 +11,12 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
+import kr.co.csalgo.application.common.dto.PagedResponse;
 import kr.co.csalgo.application.user.dto.UserDto;
 import kr.co.csalgo.domain.user.entity.User;
 import kr.co.csalgo.domain.user.service.UserService;
@@ -29,16 +34,27 @@ public class GetUserUseCaseTest {
 	@Test
 	@DisplayName("사용자 리스트 페이징 조회 테스트 성공")
 	void testGetUserListWithPagingSuccess() {
+		// given
 		List<User> users = List.of(
 			User.builder().email("user1@example.com").build(),
 			User.builder().email("user2@example.com").build()
 		);
-		when(userService.list(0, 2)).thenReturn(users);
+		Pageable pageable = PageRequest.of(0, 2);
+		Page<User> page = new PageImpl<>(users, pageable, users.size());
 
-		List<UserDto.Response> result = getUserUseCase.getUserListWithPaging(1, 2);
-		assertThat(result).hasSize(2);
-		assertThat(result.get(0).getEmail()).isEqualTo("user1@example.com");
-		assertThat(result.get(1).getEmail()).isEqualTo("user2@example.com");
+		when(userService.list(pageable)).thenReturn(page);
+
+		// when
+		PagedResponse<UserDto.Response> result = getUserUseCase.getUserListWithPaging(1, 2);
+
+		// then
+		assertThat(result.getContent()).hasSize(2);
+		assertThat(result.getContent().get(0).getEmail()).isEqualTo("user1@example.com");
+		assertThat(result.getContent().get(1).getEmail()).isEqualTo("user2@example.com");
+		assertThat(result.getCurrentPage()).isEqualTo(1);
+		assertThat(result.getTotalPages()).isEqualTo(1);
+		assertThat(result.isFirst()).isTrue();
+		assertThat(result.isLast()).isTrue();
 	}
 
 	@Test

--- a/csalgo-domain/src/main/java/kr/co/csalgo/domain/question/service/QuestionService.java
+++ b/csalgo-domain/src/main/java/kr/co/csalgo/domain/question/service/QuestionService.java
@@ -2,7 +2,7 @@ package kr.co.csalgo.domain.question.service;
 
 import java.util.List;
 
-import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
@@ -28,9 +28,8 @@ public class QuestionService {
 			.orElseThrow(() -> new CustomBusinessException(ErrorCode.QUESTION_NOT_FOUND));
 	}
 
-	public List<Question> list(int page, int size) {
-		Pageable pageable = PageRequest.of(page, size);
-		return questionRepository.findAll(pageable).getContent();
+	public Page<Question> list(Pageable pageable) {
+		return questionRepository.findAll(pageable);
 	}
 
 	public List<Question> list() {

--- a/csalgo-domain/src/main/java/kr/co/csalgo/domain/user/service/UserService.java
+++ b/csalgo-domain/src/main/java/kr/co/csalgo/domain/user/service/UserService.java
@@ -3,7 +3,7 @@ package kr.co.csalgo.domain.user.service;
 import java.util.List;
 import java.util.UUID;
 
-import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
@@ -50,9 +50,8 @@ public class UserService {
 		userRepository.delete(user);
 	}
 
-	public List<User> list(int page, int size) {
-		Pageable pageable = PageRequest.of(page, size);
-		return userRepository.findAll(pageable).getContent();
+	public Page<User> list(Pageable pageable) {
+		return userRepository.findAll(pageable);
 	}
 
 	public List<User> list() {

--- a/csalgo-domain/src/test/java/kr/co/csalgo/domain/service/QuestionServiceTest.java
+++ b/csalgo-domain/src/test/java/kr/co/csalgo/domain/service/QuestionServiceTest.java
@@ -128,6 +128,7 @@ class QuestionServiceTest {
 	@Test
 	@DisplayName("페이지 정보에 따라 질문 목록을 페이징하여 조회할 수 있다.")
 	void testListQuestionsWithPaging() {
+		// given
 		int page = 0;
 		int size = 2;
 		Pageable pageable = PageRequest.of(page, size);
@@ -138,10 +139,12 @@ class QuestionServiceTest {
 
 		when(questionRepository.findAll(pageable)).thenReturn(mockPage);
 
-		List<Question> result = questionService.list(page, size);
+		// when
+		Page<Question> result = questionService.list(pageable);
 
-		assertEquals(2, result.size());
-		assertEquals("Q1", result.get(0).getTitle());
+		// then
+		assertEquals(2, result.getContent().size());
+		assertEquals("Q1", result.getContent().get(0).getTitle());
 		verify(questionRepository).findAll(pageable);
 	}
 

--- a/csalgo-domain/src/test/java/kr/co/csalgo/domain/service/UserServiceTest.java
+++ b/csalgo-domain/src/test/java/kr/co/csalgo/domain/service/UserServiceTest.java
@@ -201,6 +201,7 @@ class UserServiceTest {
 	@Test
 	@DisplayName("페이지 정보에 따라 사용자 목록을 페이징하여 조회할 수 있다.")
 	void testUserListWithPaging() {
+		// given
 		int page = 0;
 		int size = 2;
 		Pageable pageable = PageRequest.of(page, size);
@@ -213,10 +214,15 @@ class UserServiceTest {
 
 		when(userRepository.findAll(pageable)).thenReturn(mockPage);
 
-		List<User> result = userService.list(page, size);
+		// when
+		Page<User> result = userService.list(pageable);
 
-		assertEquals(2, result.size());
-		assertEquals("user1@example.com", result.get(0).getEmail());
+		// then
+		assertEquals(2, result.getContent().size());         // 현재 페이지 데이터 개수
+		assertEquals("user1@example.com", result.getContent().get(0).getEmail());
+		assertEquals(5, result.getTotalElements());          // 전체 데이터 개수
+		assertEquals(3, result.getTotalPages());             // 총 페이지 수 (ceil(5/2) = 3)
+		assertTrue(result.hasNext());                        // 다음 페이지 존재 여부
 		verify(userRepository).findAll(pageable);
 	}
 }

--- a/csalgo-server/src/test/java/kr/co/csalgo/server/question/QuestionControllerTest.java
+++ b/csalgo-server/src/test/java/kr/co/csalgo/server/question/QuestionControllerTest.java
@@ -22,6 +22,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import kr.co.csalgo.application.common.dto.PagedResponse;
 import kr.co.csalgo.application.problem.dto.QuestionDto;
 import kr.co.csalgo.application.problem.dto.SendQuestionMailDto;
 import kr.co.csalgo.application.problem.usecase.DeleteQuestionUseCase;
@@ -122,6 +123,7 @@ class QuestionControllerTest {
 	@Test
 	@DisplayName("문제 목록 조회 성공 시 200 OK 반환")
 	void testGetQuestionListSuccess() throws Exception {
+		// given
 		QuestionDto.Response q1 = QuestionDto.Response.builder()
 			.title("문제1")
 			.solution("풀이1")
@@ -132,17 +134,31 @@ class QuestionControllerTest {
 			.solution("풀이2")
 			.build();
 
-		List<QuestionDto.Response> result = List.of(q1, q2);
+		PagedResponse<QuestionDto.Response> result = PagedResponse.<QuestionDto.Response>builder()
+			.content(List.of(q1, q2))
+			.currentPage(1)
+			.totalPages(1)
+			.totalElements(2)
+			.first(true)
+			.last(true)
+			.build();
+
 		when(getQuestionUseCase.getQuestionListWithPaging(1, 2)).thenReturn(result);
 
+		// when & then
 		mockMvc.perform(get("/api/questions")
 				.param("page", "1")
 				.param("size", "2"))
 			.andExpect(status().isOk())
-			.andExpect(jsonPath("$").isArray())
-			.andExpect(jsonPath("$.length()").value(2))
-			.andExpect(jsonPath("$[0].title").value("문제1"))
-			.andExpect(jsonPath("$[1].title").value("문제2"));
+			.andExpect(jsonPath("$.content").isArray())
+			.andExpect(jsonPath("$.content.length()").value(2))
+			.andExpect(jsonPath("$.content[0].title").value("문제1"))
+			.andExpect(jsonPath("$.content[1].title").value("문제2"))
+			.andExpect(jsonPath("$.currentPage").value(1))
+			.andExpect(jsonPath("$.totalPages").value(1))
+			.andExpect(jsonPath("$.totalElements").value(2))
+			.andExpect(jsonPath("$.first").value(true))
+			.andExpect(jsonPath("$.last").value(true));
 	}
 
 	@Test

--- a/csalgo-server/src/test/java/kr/co/csalgo/server/user/UserControllerTest.java
+++ b/csalgo-server/src/test/java/kr/co/csalgo/server/user/UserControllerTest.java
@@ -19,6 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import kr.co.csalgo.application.common.dto.PagedResponse;
 import kr.co.csalgo.application.user.dto.UserDto;
 import kr.co.csalgo.application.user.usecase.DeleteUserUseCase;
 import kr.co.csalgo.application.user.usecase.GetUserUseCase;
@@ -45,18 +46,26 @@ class UserControllerTest {
 	@Test
 	@DisplayName("사용자 목록 조회 성공 시 200 OK 반환")
 	void testGetUserListSuccess() throws Exception {
-		List<UserDto.Response> users = List.of(
-			UserDto.Response.builder()
-				.email("user1@example.com")
-				.uuid(UUID.randomUUID())
-				.build(),
-			UserDto.Response.builder()
-				.email("user2@example.com")
-				.uuid(UUID.randomUUID())
-				.build()
-		);
+		PagedResponse<UserDto.Response> pagedResponse = PagedResponse.<UserDto.Response>builder()
+			.content(List.of(
+					UserDto.Response.builder()
+						.email("user1@example.com")
+						.uuid(UUID.randomUUID())
+						.build(),
+					UserDto.Response.builder()
+						.email("user2@example.com")
+						.uuid(UUID.randomUUID())
+						.build()
+				)
+			)
+			.currentPage(1)
+			.totalPages(1)
+			.totalElements(2)
+			.first(true)
+			.last(true)
+			.build();
 
-		when(getUserUseCase.getUserListWithPaging(1, 2)).thenReturn(users);
+		when(getUserUseCase.getUserListWithPaging(1, 2)).thenReturn(pagedResponse);
 
 		mockMvc.perform(get("/api/users")
 				.param("page", "1")

--- a/csalgo-web/src/main/java/kr/co/csalgo/web/admin/controller/AdminWebController.java
+++ b/csalgo-web/src/main/java/kr/co/csalgo/web/admin/controller/AdminWebController.java
@@ -32,19 +32,19 @@ public class AdminWebController {
 		return "admin/dashboard/index";
 	}
 
-	@GetMapping("/dashboard/members")
-	public String members(
+	@GetMapping("/dashboard/users")
+	public String users(
 		@RequestParam(defaultValue = "1") int page,
 		@RequestParam(defaultValue = "10") int size,
 		@CookieValue("accessToken") String accessToken,
 		Model model
 	) {
 		ResponseEntity<?> response = adminService.getUserList(accessToken, page, size);
-		List<UserDto.Response> members = (List<UserDto.Response>)response.getBody();
-		model.addAttribute("members", members);
+		List<UserDto.Response> users = (List<UserDto.Response>)response.getBody();
+		model.addAttribute("users", users);
 		model.addAttribute("currentPage", page);
-		model.addAttribute("activeMenu", "members");
-		return "admin/dashboard/members";
+		model.addAttribute("activeMenu", "users");
+		return "admin/dashboard/users";
 	}
 
 	@PostMapping("/login")

--- a/csalgo-web/src/main/resources/templates/admin/dashboard/index.html
+++ b/csalgo-web/src/main/resources/templates/admin/dashboard/index.html
@@ -10,7 +10,7 @@
                 <div class="card-body">
                     <h5 class="card-title">회원 수</h5>
                     <p class="display-6 fw-bold">...</p>
-                    <a th:href="@{/admin/dashboard/members}" class="btn btn-primary btn-sm">회원 관리</a>
+                    <a th:href="@{/admin/dashboard/users}" class="btn btn-primary btn-sm">회원 관리</a>
                 </div>
             </div>
         </div>
@@ -20,7 +20,7 @@
                 <div class="card-body">
                     <h5 class="card-title">문제 수</h5>
                     <p class="display-6 fw-bold">...</p>
-                    <a th:href="@{/admin/dashboard/problems}" class="btn btn-primary btn-sm">문제 관리</a>
+                    <a th:href="@{/admin/dashboard/users}" class="btn btn-primary btn-sm">문제 관리</a>
                 </div>
             </div>
         </div>

--- a/csalgo-web/src/main/resources/templates/admin/dashboard/layout.html
+++ b/csalgo-web/src/main/resources/templates/admin/dashboard/layout.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <title>관리자 대시보드</title>
-    
+
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" th:href="@{/css/style.css}">
 </head>
@@ -20,8 +20,8 @@
                    th:href="@{/admin/dashboard}">대시보드 홈</a>
 
                 <a class="nav-link"
-                   th:classappend="${activeMenu}=='members' ? 'active' : ''"
-                   th:href="@{/admin/dashboard/members}">회원 관리</a>
+                   th:classappend="${activeMenu}=='users' ? 'active' : ''"
+                   th:href="@{/admin/dashboard/users}">회원 관리</a>
 
                 <a class="nav-link"
                    th:classappend="${activeMenu}=='problems' ? 'active' : ''"

--- a/csalgo-web/src/main/resources/templates/admin/dashboard/users.html
+++ b/csalgo-web/src/main/resources/templates/admin/dashboard/users.html
@@ -13,9 +13,9 @@
         </tr>
         </thead>
         <tbody>
-        <tr th:each="member, stat : ${members}">
+        <tr th:each="user, stat : ${users}">
             <td th:text="${stat.count}">1</td>
-            <td th:text="${member.email}">hong@test.com</td>
+            <td th:text="${user.email}">hong@test.com</td>
         </tr>
         </tbody>
     </table>
@@ -27,7 +27,7 @@
             <!-- 이전 버튼 -->
             <li class="page-item" th:classappend="${currentPage == 1} ? 'disabled'">
                 <a class="page-link"
-                   th:href="@{/admin/dashboard/members(page=${currentPage - 1})}">&lt;</a>
+                   th:href="@{/admin/dashboard/users(page=${currentPage - 1})}">&lt;</a>
             </li>
 
             <!-- 현재 페이지 번호 -->
@@ -38,7 +38,7 @@
             <!-- 다음 버튼 -->
             <li class="page-item">
                 <a class="page-link"
-                   th:href="@{/admin/dashboard/members(page=${currentPage + 1})}">&gt;</a>
+                   th:href="@{/admin/dashboard/users(page=${currentPage + 1})}">&gt;</a>
             </li>
         </ul>
     </nav>


### PR DESCRIPTION
<!-- (title: "[Type] Title close #IssueNumber") -->

## Motivation

<!-- 작성 배경 -->

- #131
- #133

## Problem Solving

<!-- 해결 방법 -->

- `userService` & `questionService`의 `list()` 메서드 시그니처 변경  
  - `int page, int size` → `Pageable pageable` 인자 받도록 수정  
  - 서비스 계층에서 페이징 책임을 명확히 분리  
- `PagedResponse<T>` DTO 작성  
  - 페이징된 데이터(`content`)와 메타데이터(`currentPage`, `totalPages`, `totalElements`, `first`, `last`) 함께 반환  
  - 공통 페이징 응답 구조 확립으로 Controller/API 응답 일관성 확보  
- 관련 UseCase 및 Controller 코드 수정  
  - 기존 단순 `List<T>` 반환 방식 → `PagedResponse<T>` 기반 응답 방식으로 변경  
- 관련 단위/통합 테스트 코드 수정  
  - Mocking 시 `Pageable` 객체 기반으로 검증  
  - JSON 응답 구조(`content`, `currentPage`, `totalPages`, …)에 맞게 검증 로직 보강  

## To Reviewer

<!-- 리뷰어에게 말하고 싶은 것, 유의 깊게 봐주었으면 하는 것, 의문점 등 -->

### 🏃 Postman (문제 목록 조회 API)

<img width="400" alt="image" src="https://github.com/user-attachments/assets/6a9550cf-7d1c-4e0c-9e48-698dae93dfe5" />

- 사용자 목록 API는 개인정보로 인해 업로드 생략합니다. (정상 동작 확인 완료)