### PR TITLE
[Fix] 사용자 목록 조회 API 수정에 따른 대시보드 페이지네이션 적용 #133

### DIFF
--- a/csalgo-web/src/main/java/kr/co/csalgo/web/admin/client/AdminRestClient.java
+++ b/csalgo-web/src/main/java/kr/co/csalgo/web/admin/client/AdminRestClient.java
@@ -1,7 +1,5 @@
 package kr.co.csalgo.web.admin.client;
 
-import java.util.List;
-
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
@@ -10,6 +8,7 @@ import org.springframework.web.client.RestClient;
 import kr.co.csalgo.web.admin.dto.AdminLoginDto;
 import kr.co.csalgo.web.admin.dto.AdminRefreshDto;
 import kr.co.csalgo.web.admin.dto.UserDto;
+import kr.co.csalgo.web.common.dto.PagedResponse;
 import lombok.RequiredArgsConstructor;
 
 @Component
@@ -46,7 +45,7 @@ public class AdminRestClient {
 			.uri("/users?page={page}&size={size}", page, size)
 			.header("Authorization", "Bearer " + accessToken)
 			.retrieve()
-			.toEntity(new ParameterizedTypeReference<List<UserDto.Response>>() {
+			.toEntity(new ParameterizedTypeReference<PagedResponse<UserDto.Response>>() {
 			});
 	}
 }

--- a/csalgo-web/src/main/java/kr/co/csalgo/web/admin/controller/AdminWebController.java
+++ b/csalgo-web/src/main/java/kr/co/csalgo/web/admin/controller/AdminWebController.java
@@ -26,7 +26,20 @@ public class AdminWebController {
 	}
 
 	@GetMapping("/dashboard")
-	public String dashboard(Model model) {
+	public String dashboard(
+		@CookieValue("accessToken") String accessToken,
+		Model model
+	) {
+		// 회원 수 조회 (0페이지, size=1로 최소 조회)
+		ResponseEntity<?> userResponse = adminService.getUserList(accessToken, 1, 1);
+		@SuppressWarnings("unchecked")
+		PagedResponse<UserDto.Response> userBody = (PagedResponse<UserDto.Response>)userResponse.getBody();
+		long userCount = (userBody != null) ? userBody.getTotalElements() : 0;
+
+		// TODO: 문제 수 조회 (마찬가지로 최소 페이지 조회)
+
+		model.addAttribute("userCount", userCount);
+		model.addAttribute("questionCount", "...");
 		model.addAttribute("activeMenu", "dashboard");
 		return "admin/dashboard/index";
 	}

--- a/csalgo-web/src/main/java/kr/co/csalgo/web/admin/controller/AdminWebController.java
+++ b/csalgo-web/src/main/java/kr/co/csalgo/web/admin/controller/AdminWebController.java
@@ -1,7 +1,5 @@
 package kr.co.csalgo.web.admin.controller;
 
-import java.util.List;
-
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -13,6 +11,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 
 import kr.co.csalgo.web.admin.dto.UserDto;
 import kr.co.csalgo.web.admin.service.AdminService;
+import kr.co.csalgo.web.common.dto.PagedResponse;
 import lombok.RequiredArgsConstructor;
 
 @Controller
@@ -40,8 +39,8 @@ public class AdminWebController {
 		Model model
 	) {
 		ResponseEntity<?> response = adminService.getUserList(accessToken, page, size);
-		List<UserDto.Response> users = (List<UserDto.Response>)response.getBody();
-		model.addAttribute("users", users);
+		PagedResponse<UserDto.Response> body = (PagedResponse<UserDto.Response>)response.getBody();
+		model.addAttribute("users", body.getContent());
 		model.addAttribute("currentPage", page);
 		model.addAttribute("activeMenu", "users");
 		return "admin/dashboard/users";

--- a/csalgo-web/src/main/java/kr/co/csalgo/web/admin/controller/AdminWebController.java
+++ b/csalgo-web/src/main/java/kr/co/csalgo/web/admin/controller/AdminWebController.java
@@ -39,10 +39,16 @@ public class AdminWebController {
 		Model model
 	) {
 		ResponseEntity<?> response = adminService.getUserList(accessToken, page, size);
+		@SuppressWarnings("unchecked")
 		PagedResponse<UserDto.Response> body = (PagedResponse<UserDto.Response>)response.getBody();
+
 		model.addAttribute("users", body.getContent());
-		model.addAttribute("currentPage", page);
+		model.addAttribute("currentPage", body.getCurrentPage());
+		model.addAttribute("totalPages", body.getTotalPages());
+		model.addAttribute("first", body.isFirst());
+		model.addAttribute("last", body.isLast());
 		model.addAttribute("activeMenu", "users");
+
 		return "admin/dashboard/users";
 	}
 

--- a/csalgo-web/src/main/java/kr/co/csalgo/web/admin/dto/UserDto.java
+++ b/csalgo-web/src/main/java/kr/co/csalgo/web/admin/dto/UserDto.java
@@ -1,6 +1,7 @@
 package kr.co.csalgo.web.admin.dto;
 
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 import lombok.Builder;
 import lombok.Getter;
@@ -21,15 +22,15 @@ public class UserDto {
 	@Getter
 	@NoArgsConstructor
 	public static class Response {
-		private int id;
+		private Long id;
 		private String email;
 		private String role;
-		private String uuid;
+		private UUID uuid;
 		private LocalDateTime createdAt;
 		private LocalDateTime updatedAt;
 
 		@Builder
-		public Response(int id, String email, String role, String uuid, LocalDateTime createdAt, LocalDateTime updatedAt) {
+		public Response(Long id, String email, String role, UUID uuid, LocalDateTime createdAt, LocalDateTime updatedAt) {
 			this.id = id;
 			this.email = email;
 			this.role = role;

--- a/csalgo-web/src/main/java/kr/co/csalgo/web/common/dto/PagedResponse.java
+++ b/csalgo-web/src/main/java/kr/co/csalgo/web/common/dto/PagedResponse.java
@@ -1,0 +1,28 @@
+package kr.co.csalgo.web.common.dto;
+
+import java.util.List;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class PagedResponse<T> {
+	private List<T> content;
+	private int currentPage;
+	private int totalPages;
+	private long totalElements;
+	private boolean first;
+	private boolean last;
+
+	@Builder
+	public PagedResponse(List<T> content, int currentPage, int totalPages, long totalElements, boolean first, boolean last) {
+		this.content = content;
+		this.currentPage = currentPage;
+		this.totalPages = totalPages;
+		this.totalElements = totalElements;
+		this.first = first;
+		this.last = last;
+	}
+}

--- a/csalgo-web/src/main/resources/templates/admin/dashboard/index.html
+++ b/csalgo-web/src/main/resources/templates/admin/dashboard/index.html
@@ -9,7 +9,7 @@
             <div class="card text-center shadow-sm">
                 <div class="card-body">
                     <h5 class="card-title">회원 수</h5>
-                    <p class="display-6 fw-bold">...</p>
+                    <p class="display-6 fw-bold" th:text="${userCount}">0</p>
                     <a th:href="@{/admin/dashboard/users}" class="btn btn-primary btn-sm">회원 관리</a>
                 </div>
             </div>
@@ -19,11 +19,12 @@
             <div class="card text-center shadow-sm">
                 <div class="card-body">
                     <h5 class="card-title">문제 수</h5>
-                    <p class="display-6 fw-bold">...</p>
-                    <a th:href="@{/admin/dashboard/users}" class="btn btn-primary btn-sm">문제 관리</a>
+                    <p class="display-6 fw-bold" th:text="${questionCount}">0</p>
+                    <a th:href="@{/admin/dashboard/questions}" class="btn btn-primary btn-sm">문제 관리</a>
                 </div>
             </div>
         </div>
     </div>
+
 </div>
 </html>

--- a/csalgo-web/src/main/resources/templates/admin/dashboard/users.html
+++ b/csalgo-web/src/main/resources/templates/admin/dashboard/users.html
@@ -4,41 +4,51 @@
     <h3 class="fw-bold mb-4">회원 관리</h3>
     <p class="text-muted">회원 목록을 조회하고 관리할 수 있습니다.</p>
 
-    <!-- 회원 목록 테이블 -->
     <table class="table table-hover">
         <thead>
         <tr>
             <th>#</th>
             <th>이메일</th>
+            <th>역할</th>
+            <th>UUID</th>
+            <th>가입일</th>
+            <th>수정일</th>
         </tr>
         </thead>
         <tbody>
         <tr th:each="user, stat : ${users}">
             <td th:text="${stat.count}">1</td>
             <td th:text="${user.email}">hong@test.com</td>
+            <td>
+        <span th:text="${user.role}"
+              th:classappend="
+                ${user.role == 'ADMIN'} ? 'badge bg-primary' :
+                (${user.role == 'MANAGER'} ? 'badge bg-success' : 'badge bg-secondary')
+              ">
+            ADMIN
+        </span>
+            </td>
+            <td th:text="${user.uuid}">3c2e82ad-2951-4a63-8123-c975c7b50a55</td>
+            <td th:text="${#temporals.format(user.createdAt, 'yyyy-MM-dd HH:mm')}">2025-08-20 12:00</td>
+            <td th:text="${#temporals.format(user.updatedAt, 'yyyy-MM-dd HH:mm')}">2025-08-20 12:30</td>
         </tr>
         </tbody>
     </table>
 
-    <!-- 임시로 페이지네이션 미적용: < 현재페이지 > -->
-    <!-- TODO: 페이지네이션 적용 및 API spec 수정 -->
     <nav>
         <ul class="pagination justify-content-center">
-            <!-- 이전 버튼 -->
             <li class="page-item" th:classappend="${currentPage == 1} ? 'disabled'">
                 <a class="page-link"
-                   th:href="@{/admin/dashboard/users(page=${currentPage - 1})}">&lt;</a>
+                   th:href="@{/admin/dashboard/users(page=${currentPage - 1}, size=${10})}">&lt;</a>
             </li>
 
-            <!-- 현재 페이지 번호 -->
             <li class="page-item active">
                 <span class="page-link" th:text="${currentPage}">1</span>
             </li>
 
-            <!-- 다음 버튼 -->
-            <li class="page-item">
+            <li class="page-item" th:classappend="${last} ? 'disabled'">
                 <a class="page-link"
-                   th:href="@{/admin/dashboard/users(page=${currentPage + 1})}">&gt;</a>
+                   th:href="@{/admin/dashboard/users(page=${currentPage + 1}, size=${10})}">&gt;</a>
             </li>
         </ul>
     </nav>


### PR DESCRIPTION
<!-- (title: "[Type] Title close #IssueNumber") -->

## Motivation

<!-- 작성 배경 -->

- resolve #133 

## Problem Solving

<!-- 해결 방법 -->

### 관리자 대시보드 - 메인

- 사용자 목록 조회 API를 요청하여 전체 사용자 수를 가져오도록 구현하였음

### 관리자 대시보드 - 회원 목록 UI

- `csalgo-web` 모듈에 PagedResponse(DTO) 추가
  - 기존 `UserDto` 필드 타입 수정
- 사용자 목록 조회 API 응답 필드 수정에 따른 UI 수정

## To Reviewer

<!-- 리뷰어에게 말하고 싶은 것, 유의 깊게 봐주었으면 하는 것, 의문점 등 -->

### 🎨 관리자 대시보드 UI

| 대시보드 홈 | 회원 목록 |
| --- | --- |
| <img width="1920" height="1055" alt="image" src="https://github.com/user-attachments/assets/eeeffae3-c39b-47d1-a253-c450b6c8aa38" /> | <img width="1920" height="1055" alt="image" src="https://github.com/user-attachments/assets/3f8b8efb-9f93-41d9-b67b-148075e2b2a7" /> |