### PR TITLE
[Feature] 관리자 문제 목록 조회 페이지 구현 #131

### DIFF
--- a/csalgo-web/src/main/java/kr/co/csalgo/web/admin/client/AdminRestClient.java
+++ b/csalgo-web/src/main/java/kr/co/csalgo/web/admin/client/AdminRestClient.java
@@ -10,6 +10,7 @@ import org.springframework.web.client.RestClientResponseException;
 
 import kr.co.csalgo.web.admin.dto.AdminLoginDto;
 import kr.co.csalgo.web.admin.dto.AdminRefreshDto;
+import kr.co.csalgo.web.admin.dto.QuestonDto;
 import kr.co.csalgo.web.admin.dto.UserDto;
 import kr.co.csalgo.web.common.dto.PagedResponse;
 import lombok.RequiredArgsConstructor;
@@ -64,6 +65,20 @@ public class AdminRestClient {
 		);
 	}
 
+	/** 문제 목록 조회 */
+	public ResponseEntity<PagedResponse<QuestonDto.Response>> getQuestionList(String accessToken, String refreshToken, int page, int size) {
+		return executeWithRetry(
+			accessToken,
+			refreshToken,
+			token -> restClient.get()
+				.uri("/questions?page={page}&size={size}", page, size)
+				.header("Authorization", "Bearer " + token)
+				.retrieve()
+				.toEntity(new ParameterizedTypeReference<PagedResponse<QuestonDto.Response>>() {
+				})
+		);
+	}
+
 	/** 공통 재시도 로직 */
 	private <T> ResponseEntity<T> executeWithRetry(
 		String accessToken,
@@ -87,5 +102,4 @@ public class AdminRestClient {
 			throw ex;
 		}
 	}
-
 }

--- a/csalgo-web/src/main/java/kr/co/csalgo/web/admin/client/AdminRestClient.java
+++ b/csalgo-web/src/main/java/kr/co/csalgo/web/admin/client/AdminRestClient.java
@@ -1,13 +1,17 @@
 package kr.co.csalgo.web.admin.client;
 
+import java.time.Duration;
 import java.util.function.Function;
 
 import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestClientResponseException;
 
+import jakarta.servlet.http.HttpServletResponse;
 import kr.co.csalgo.web.admin.dto.AdminLoginDto;
 import kr.co.csalgo.web.admin.dto.AdminRefreshDto;
 import kr.co.csalgo.web.admin.dto.QuestonDto;
@@ -38,21 +42,9 @@ public class AdminRestClient {
 			.toEntity(AdminRefreshDto.Response.class);
 	}
 
-	/** 단일 사용자 조회 */
-	public ResponseEntity<UserDto.Response> getUser(String accessToken, String refreshToken, int id) {
-		return executeWithRetry(
-			accessToken,
-			refreshToken,
-			token -> restClient.get()
-				.uri("/users/{id}", id)
-				.header("Authorization", "Bearer " + token)
-				.retrieve()
-				.toEntity(UserDto.Response.class)
-		);
-	}
-
 	/** 사용자 목록 조회 */
-	public ResponseEntity<PagedResponse<UserDto.Response>> getUserList(String accessToken, String refreshToken, int page, int size) {
+	public ResponseEntity<PagedResponse<UserDto.Response>> getUserList(String accessToken, String refreshToken, int page, int size,
+		HttpServletResponse response) {
 		return executeWithRetry(
 			accessToken,
 			refreshToken,
@@ -61,12 +53,14 @@ public class AdminRestClient {
 				.header("Authorization", "Bearer " + token)
 				.retrieve()
 				.toEntity(new ParameterizedTypeReference<PagedResponse<UserDto.Response>>() {
-				})
+				}),
+			response
 		);
 	}
 
 	/** 문제 목록 조회 */
-	public ResponseEntity<PagedResponse<QuestonDto.Response>> getQuestionList(String accessToken, String refreshToken, int page, int size) {
+	public ResponseEntity<PagedResponse<QuestonDto.Response>> getQuestionList(String accessToken, String refreshToken, int page, int size,
+		HttpServletResponse response) {
 		return executeWithRetry(
 			accessToken,
 			refreshToken,
@@ -75,7 +69,8 @@ public class AdminRestClient {
 				.header("Authorization", "Bearer " + token)
 				.retrieve()
 				.toEntity(new ParameterizedTypeReference<PagedResponse<QuestonDto.Response>>() {
-				})
+				}),
+			response
 		);
 	}
 
@@ -83,7 +78,8 @@ public class AdminRestClient {
 	private <T> ResponseEntity<T> executeWithRetry(
 		String accessToken,
 		String refreshToken,
-		Function<String, ResponseEntity<T>> requestFn
+		Function<String, ResponseEntity<T>> requestFn,
+		HttpServletResponse response
 	) {
 		try {
 			return requestFn.apply(accessToken);
@@ -95,11 +91,30 @@ public class AdminRestClient {
 
 				if (refreshRes.getStatusCode().is2xxSuccessful() && refreshRes.getBody() != null) {
 					String newAccessToken = refreshRes.getBody().getAccessToken();
+					String newRefreshToken = refreshRes.getBody().getRefreshToken();
+
+					// 2. 새로운 RefreshToken을 쿠키에 저장
+					updateRefreshTokenCookie(response, newRefreshToken);
+
+					// 3. 새로운 AccessToken으로 재호출
 					return requestFn.apply(newAccessToken);
 				}
 			}
 			// 다른 오류는 그대로 throw
 			throw ex;
 		}
+	}
+
+	/** Refresh Token 쿠키 업데이트 */
+	private void updateRefreshTokenCookie(HttpServletResponse response, String newRefreshToken) {
+		ResponseCookie cookie = ResponseCookie.from("refreshToken", newRefreshToken)
+			.httpOnly(true)
+			.secure(true)
+			.path("/")
+			.maxAge(Duration.ofDays(30))
+			.secure(true)
+			.build();
+
+		response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
 	}
 }

--- a/csalgo-web/src/main/java/kr/co/csalgo/web/admin/controller/AdminWebController.java
+++ b/csalgo-web/src/main/java/kr/co/csalgo/web/admin/controller/AdminWebController.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
+import kr.co.csalgo.web.admin.dto.QuestonDto;
 import kr.co.csalgo.web.admin.dto.UserDto;
 import kr.co.csalgo.web.admin.service.AdminService;
 import kr.co.csalgo.web.common.dto.PagedResponse;
@@ -65,6 +66,28 @@ public class AdminWebController {
 		model.addAttribute("activeMenu", "users");
 
 		return "admin/dashboard/users";
+	}
+
+	@GetMapping("/dashboard/questions")
+	public String questions(
+		@RequestParam(defaultValue = "1") int page,
+		@RequestParam(defaultValue = "10") int size,
+		@CookieValue("accessToken") String accessToken,
+		@CookieValue("refreshToken") String refreshToken,
+		Model model
+	) {
+		ResponseEntity<?> response = adminService.getQuestionList(accessToken, refreshToken, page, size);
+		@SuppressWarnings("unchecked")
+		PagedResponse<QuestonDto.Response> body = (PagedResponse<QuestonDto.Response>)response.getBody();
+
+		model.addAttribute("questions", body.getContent());
+		model.addAttribute("currentPage", body.getCurrentPage());
+		model.addAttribute("totalPages", body.getTotalPages());
+		model.addAttribute("first", body.isFirst());
+		model.addAttribute("last", body.isLast());
+		model.addAttribute("activeMenu", "questions");
+
+		return "admin/dashboard/questions";
 	}
 
 	@PostMapping("/login")

--- a/csalgo-web/src/main/java/kr/co/csalgo/web/admin/controller/AdminWebController.java
+++ b/csalgo-web/src/main/java/kr/co/csalgo/web/admin/controller/AdminWebController.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
+import jakarta.servlet.http.HttpServletResponse;
 import kr.co.csalgo.web.admin.dto.QuestonDto;
 import kr.co.csalgo.web.admin.dto.UserDto;
 import kr.co.csalgo.web.admin.service.AdminService;
@@ -30,15 +31,16 @@ public class AdminWebController {
 	public String dashboard(
 		@CookieValue("accessToken") String accessToken,
 		@CookieValue("refreshToken") String refreshToken,
+		HttpServletResponse httpServletResponse,
 		Model model
 	) {
 		// 회원 수 조회 (0페이지, size=1로 최소 조회)
-		ResponseEntity<?> userResponse = adminService.getUserList(accessToken, refreshToken, 1, 1);
+		ResponseEntity<?> userResponse = adminService.getUserList(accessToken, refreshToken, 1, 1, httpServletResponse);
 		@SuppressWarnings("unchecked")
 		PagedResponse<UserDto.Response> userBody = (PagedResponse<UserDto.Response>)userResponse.getBody();
 		long userCount = (userBody != null) ? userBody.getTotalElements() : 0;
 
-		ResponseEntity<?> questionResponse = adminService.getQuestionList(accessToken, refreshToken, 1, 1);
+		ResponseEntity<?> questionResponse = adminService.getQuestionList(accessToken, refreshToken, 1, 1, httpServletResponse);
 		@SuppressWarnings("unchecked")
 		PagedResponse<QuestonDto.Response> questionBody = (PagedResponse<QuestonDto.Response>)questionResponse.getBody();
 		long questionCount = (questionBody != null) ? questionBody.getTotalElements() : 0;
@@ -55,9 +57,10 @@ public class AdminWebController {
 		@RequestParam(defaultValue = "10") int size,
 		@CookieValue("accessToken") String accessToken,
 		@CookieValue("refreshToken") String refreshToken,
+		HttpServletResponse httpServletResponse,
 		Model model
 	) {
-		ResponseEntity<?> response = adminService.getUserList(accessToken, refreshToken, page, size);
+		ResponseEntity<?> response = adminService.getUserList(accessToken, refreshToken, page, size, httpServletResponse);
 		@SuppressWarnings("unchecked")
 		PagedResponse<UserDto.Response> body = (PagedResponse<UserDto.Response>)response.getBody();
 
@@ -77,9 +80,10 @@ public class AdminWebController {
 		@RequestParam(defaultValue = "10") int size,
 		@CookieValue("accessToken") String accessToken,
 		@CookieValue("refreshToken") String refreshToken,
+		HttpServletResponse httpServletResponse,
 		Model model
 	) {
-		ResponseEntity<?> response = adminService.getQuestionList(accessToken, refreshToken, page, size);
+		ResponseEntity<?> response = adminService.getQuestionList(accessToken, refreshToken, page, size, httpServletResponse);
 		@SuppressWarnings("unchecked")
 		PagedResponse<QuestonDto.Response> body = (PagedResponse<QuestonDto.Response>)response.getBody();
 

--- a/csalgo-web/src/main/java/kr/co/csalgo/web/admin/controller/AdminWebController.java
+++ b/csalgo-web/src/main/java/kr/co/csalgo/web/admin/controller/AdminWebController.java
@@ -38,10 +38,13 @@ public class AdminWebController {
 		PagedResponse<UserDto.Response> userBody = (PagedResponse<UserDto.Response>)userResponse.getBody();
 		long userCount = (userBody != null) ? userBody.getTotalElements() : 0;
 
-		// TODO: 문제 수 조회 (마찬가지로 최소 페이지 조회)
+		ResponseEntity<?> questionResponse = adminService.getQuestionList(accessToken, refreshToken, 1, 1);
+		@SuppressWarnings("unchecked")
+		PagedResponse<QuestonDto.Response> questionBody = (PagedResponse<QuestonDto.Response>)questionResponse.getBody();
+		long questionCount = (questionBody != null) ? questionBody.getTotalElements() : 0;
 
 		model.addAttribute("userCount", userCount);
-		model.addAttribute("questionCount", "...");
+		model.addAttribute("questionCount", questionCount);
 		model.addAttribute("activeMenu", "dashboard");
 		return "admin/dashboard/index";
 	}

--- a/csalgo-web/src/main/java/kr/co/csalgo/web/admin/dto/QuestonDto.java
+++ b/csalgo-web/src/main/java/kr/co/csalgo/web/admin/dto/QuestonDto.java
@@ -1,0 +1,30 @@
+package kr.co.csalgo.web.admin.dto;
+
+import java.time.LocalDateTime;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class QuestonDto {
+	@Getter
+	@NoArgsConstructor
+	public static class Response {
+		private Long id;
+		private String title;
+		private String description;
+		private String solution;
+		private LocalDateTime createdAt;
+		private LocalDateTime updatedAt;
+
+		@Builder
+		public Response(Long id, String title, String description, String solution, LocalDateTime createdAt, LocalDateTime updatedAt) {
+			this.id = id;
+			this.title = title;
+			this.description = description;
+			this.solution = solution;
+			this.createdAt = createdAt;
+			this.updatedAt = updatedAt;
+		}
+	}
+}

--- a/csalgo-web/src/main/java/kr/co/csalgo/web/admin/service/AdminService.java
+++ b/csalgo-web/src/main/java/kr/co/csalgo/web/admin/service/AdminService.java
@@ -23,5 +23,9 @@ public class AdminService {
 	public ResponseEntity<?> getUserList(String accessToken, String refreshToken, int page, int size) {
 		return adminRestClient.getUserList(accessToken, refreshToken, page, size);
 	}
+
+	public ResponseEntity<?> getQuestionList(String accessToken, String refreshToken, int page, int size) {
+		return adminRestClient.getQuestionList(accessToken, refreshToken, page, size);
+	}
 }
 

--- a/csalgo-web/src/main/java/kr/co/csalgo/web/admin/service/AdminService.java
+++ b/csalgo-web/src/main/java/kr/co/csalgo/web/admin/service/AdminService.java
@@ -3,6 +3,7 @@ package kr.co.csalgo.web.admin.service;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
+import jakarta.servlet.http.HttpServletResponse;
 import kr.co.csalgo.web.admin.client.AdminRestClient;
 import kr.co.csalgo.web.admin.dto.AdminLoginDto;
 import lombok.RequiredArgsConstructor;
@@ -16,16 +17,12 @@ public class AdminService {
 		return adminRestClient.login(new AdminLoginDto.Request(email, password));
 	}
 
-	public ResponseEntity<?> getUser(String accessToken, String refreshToken, int id) {
-		return adminRestClient.getUser(accessToken, refreshToken, id);
+	public ResponseEntity<?> getUserList(String accessToken, String refreshToken, int page, int size, HttpServletResponse httpServletResponse) {
+		return adminRestClient.getUserList(accessToken, refreshToken, page, size, httpServletResponse);
 	}
 
-	public ResponseEntity<?> getUserList(String accessToken, String refreshToken, int page, int size) {
-		return adminRestClient.getUserList(accessToken, refreshToken, page, size);
-	}
-
-	public ResponseEntity<?> getQuestionList(String accessToken, String refreshToken, int page, int size) {
-		return adminRestClient.getQuestionList(accessToken, refreshToken, page, size);
+	public ResponseEntity<?> getQuestionList(String accessToken, String refreshToken, int page, int size, HttpServletResponse httpServletResponse) {
+		return adminRestClient.getQuestionList(accessToken, refreshToken, page, size, httpServletResponse);
 	}
 }
 

--- a/csalgo-web/src/main/resources/templates/admin/dashboard/layout.html
+++ b/csalgo-web/src/main/resources/templates/admin/dashboard/layout.html
@@ -24,7 +24,7 @@
                    th:href="@{/admin/dashboard/users}">회원 관리</a>
 
                 <a class="nav-link"
-                   th:classappend="${activeMenu}=='problems' ? 'active' : ''"
+                   th:classappend="${activeMenu}=='questions' ? 'active' : ''"
                    th:href="@{/admin/dashboard/problems}">문제 관리</a>
             </nav>
         </nav>

--- a/csalgo-web/src/main/resources/templates/admin/dashboard/questions.html
+++ b/csalgo-web/src/main/resources/templates/admin/dashboard/questions.html
@@ -34,11 +34,15 @@
                    th:href="@{/admin/dashboard/questions(page=${currentPage - 1}, size=${10})}">&lt;</a>
             </li>
 
-            <li class="page-item active">
-                <span class="page-link" th:text="${currentPage}">1</span>
+            <li class="page-item"
+                th:each="page : ${#numbers.sequence(1, totalPages)}"
+                th:classappend="${page == currentPage} ? 'active'">
+                <a class="page-link"
+                   th:href="@{/admin/dashboard/questions(page=${page}, size=${10})}"
+                   th:text="${page}">1</a>
             </li>
 
-            <li class="page-item" th:classappend="${last} ? 'disabled'">
+            <li class="page-item" th:classappend="${currentPage == totalPages} ? 'disabled'">
                 <a class="page-link"
                    th:href="@{/admin/dashboard/questions(page=${currentPage + 1}, size=${10})}">&gt;</a>
             </li>

--- a/csalgo-web/src/main/resources/templates/admin/dashboard/questions.html
+++ b/csalgo-web/src/main/resources/templates/admin/dashboard/questions.html
@@ -1,0 +1,48 @@
+<html xmlns:th="http://www.thymeleaf.org"
+      th:replace="~{admin/dashboard/layout :: layout(~{::contentFragment})}">
+<div th:fragment="contentFragment">
+    <h3 class="fw-bold mb-4">문제 관리</h3>
+    <p class="text-muted">문제 목록을 조회하고 관리할 수 있습니다.</p>
+
+    <table class="table table-hover">
+        <thead>
+        <tr>
+            <th>#</th>
+            <th>문제 제목</th>
+            <th>문제 설명</th>
+            <th>모범답안</th>
+            <th>작성일</th>
+            <th>수정일</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr th:each="question, stat : ${questions}">
+            <td th:text="${question.id}">1</td>
+            <td th:text="${question.title}">문제 제목</td>
+            <td th:text="${question.title}">문제 설명</td>
+            <td th:text="${question.solution}">모범답안</td>
+            <td th:text="${#temporals.format(question.createdAt, 'yyyy-MM-dd HH:mm')}">2025-08-20 12:00</td>
+            <td th:text="${#temporals.format(question.updatedAt, 'yyyy-MM-dd HH:mm')}">2025-08-20 12:30</td>
+        </tr>
+        </tbody>
+    </table>
+
+    <nav>
+        <ul class="pagination justify-content-center">
+            <li class="page-item" th:classappend="${currentPage == 1} ? 'disabled'">
+                <a class="page-link"
+                   th:href="@{/admin/dashboard/questions(page=${currentPage - 1}, size=${10})}">&lt;</a>
+            </li>
+
+            <li class="page-item active">
+                <span class="page-link" th:text="${currentPage}">1</span>
+            </li>
+
+            <li class="page-item" th:classappend="${last} ? 'disabled'">
+                <a class="page-link"
+                   th:href="@{/admin/dashboard/questions(page=${currentPage + 1}, size=${10})}">&gt;</a>
+            </li>
+        </ul>
+    </nav>
+</div>
+</html>

--- a/csalgo-web/src/main/resources/templates/admin/dashboard/questions.html
+++ b/csalgo-web/src/main/resources/templates/admin/dashboard/questions.html
@@ -19,7 +19,7 @@
         <tr th:each="question, stat : ${questions}">
             <td th:text="${question.id}">1</td>
             <td th:text="${question.title}">문제 제목</td>
-            <td th:text="${question.title}">문제 설명</td>
+            <td th:text="${question.description}">문제 설명</td>
             <td th:text="${question.solution}">모범답안</td>
             <td th:text="${#temporals.format(question.createdAt, 'yyyy-MM-dd HH:mm')}">2025-08-20 12:00</td>
             <td th:text="${#temporals.format(question.updatedAt, 'yyyy-MM-dd HH:mm')}">2025-08-20 12:30</td>

--- a/csalgo-web/src/main/resources/templates/admin/dashboard/users.html
+++ b/csalgo-web/src/main/resources/templates/admin/dashboard/users.html
@@ -39,16 +39,20 @@
         <ul class="pagination justify-content-center">
             <li class="page-item" th:classappend="${currentPage == 1} ? 'disabled'">
                 <a class="page-link"
-                   th:href="@{/admin/dashboard/users(page=${currentPage - 1}, size=${10})}">&lt;</a>
+                   th:href="@{/admin/dashboard/questions(page=${currentPage - 1}, size=${10})}">&lt;</a>
             </li>
 
-            <li class="page-item active">
-                <span class="page-link" th:text="${currentPage}">1</span>
-            </li>
-
-            <li class="page-item" th:classappend="${last} ? 'disabled'">
+            <li class="page-item"
+                th:each="page : ${#numbers.sequence(1, totalPages)}"
+                th:classappend="${page == currentPage} ? 'active'">
                 <a class="page-link"
-                   th:href="@{/admin/dashboard/users(page=${currentPage + 1}, size=${10})}">&gt;</a>
+                   th:href="@{/admin/dashboard/questions(page=${page}, size=${10})}"
+                   th:text="${page}">1</a>
+            </li>
+
+            <li class="page-item" th:classappend="${currentPage == totalPages} ? 'disabled'">
+                <a class="page-link"
+                   th:href="@{/admin/dashboard/questions(page=${currentPage + 1}, size=${10})}">&gt;</a>
             </li>
         </ul>
     </nav>


### PR DESCRIPTION
<!-- (title: "[Type] Title close #IssueNumber") -->

## Motivation

<!-- 작성 배경 -->

- resolve #131 

## Problem Solving

<!-- 해결 방법 -->

- `/admin/dashboard/questions.html` 작성
- 페이지네이션 UI 수정
  - 기존: `이전 페이지 버튼`, `현재 페이지`, `다음 페이지 버튼`만 존재하였음
  - 수정: `이전 페이지 버튼`, `1 ~ 마지막 페이지 번호 전체 출력`, `다음 페이지 버튼`
- 문제 목록 API 호출을 위한 작업
  - AdminWebController > `questions` 메서드 구현
  - AdminService > `getQuestionList` 메서드 구현
  - AdminClient > `getQuestionList` 메서드 구현 (API 호출 담당)

## To Reviewer

<!-- 리뷰어에게 말하고 싶은 것, 유의 깊게 봐주었으면 하는 것, 의문점 등 -->

### 🌟 발생한 이슈: RTR 방식을 통해 재발급된 RT가 Client Cookie에 저장되지 않고 있었음

- 상황: #192를 통해 해결한 줄 알았으나, 재발급된 RT가 사용자 브라우저의 쿠키에 갱신되지 않고 있는 문제를 발견하였습니다.
- 해결 방법: 재발급된 RT를 사용자 브라우저 Cooke에 저장하기 위해 HttpServletResponse를 메서드 인자로 추가하였습니다.

#### 결과

```
2025-08-22 17:04:30.491 [http-nio-8080-exec-10] INFO  [a249a086-d2fb-4547-a065-a42d0f20b36e] k.c.c.a.a.usecase.AdminLoginUseCase - 관리자 로그인 성공: {admin_id}
2025-08-22 17:04:30.761 [http-nio-8080-exec-2] INFO  [6ef996e8-723d-4213-a062-ba1e85d36983] k.c.c.a.p.usecase.GetQuestionUseCase - [문제 리스트 조회 완료] count:1, page:1/75
2025-08-22 17:05:53.358 [http-nio-8080-exec-5] INFO  [232c551e-4eac-4149-b76a-b085025e2849] k.c.c.a.a.u.AdminRefreshTokenUseCase - 리프레시 토큰 재발급 성공: {admin_id}
2025-08-22 17:06:03.336 [http-nio-8080-exec-8] INFO  [5604adcf-f6e5-4f74-934f-d4358f843060] k.c.c.a.a.u.AdminRefreshTokenUseCase - 리프레시 토큰 재발급 성공: {admin_id}
2025-08-22 17:06:03.477 [http-nio-8080-exec-9] INFO  [b7ac1ff2-abd2-415c-bc0d-fae0883515fd] k.c.c.a.p.usecase.GetQuestionUseCase - [문제 리스트 조회 완료] count:10, page:1/8
```

- Local에서 AT 만료 기간을 3초로 설정 후 테스트하여 정상 동작 확인하였습니다.

#### AccessToken 만료 시 처리 과정 (RTR 방식)

1. API 호출 시 AccessToken이 만료되면 서버에서 401 Unauthorized 응답 발생
2. `executeWithRetry`에서 RefreshToken을 사용해 새로운 AccessToken/RefreshToken 발급 요청
3. Refresh 성공 시:
  - 새 AccessToken으로 API 재호출
  - 새 RefreshToken을 HttpServletResponse.addHeader("Set-Cookie", ...)로 응답에 포함
4. 브라우저(Client)는 Set-Cookie 헤더(c709769ec43a808cda97e5e14c216aa5b51d8c79 참고)를 보고 자동으로 쿠키를 갱신
5. 클라이언트는 별도의 로직 없이 이후 요청부터 자동으로 최신 RefreshToken 사용 가능

### Web UI

| 대시보드 | 문제 목록 |
| --- | --- |
| <img width="1920" height="1055" alt="image" src="https://github.com/user-attachments/assets/ab3787e9-e4b6-43f7-b039-04f6dab57d50" /> | <img width="1920" height="1055" alt="image" src="https://github.com/user-attachments/assets/198b2811-7907-4ae3-8966-20eb6401e77d" /> |