### PR TITLE
[Feature] 어드민 페이지 사용자 삭제 기능 연동 #195

### DIFF
--- a/csalgo-web/src/main/java/kr/co/csalgo/web/admin/client/AdminRestClient.java
+++ b/csalgo-web/src/main/java/kr/co/csalgo/web/admin/client/AdminRestClient.java
@@ -58,6 +58,20 @@ public class AdminRestClient {
 		);
 	}
 
+	/** 사용자 삭제 */
+	public ResponseEntity<Void> deleteUser(String accessToken, String refreshToken, Long userId, HttpServletResponse response) {
+		return executeWithRetry(
+			accessToken,
+			refreshToken,
+			token -> restClient.delete()
+				.uri("/users/{userId}", userId)
+				.header("Authorization", "Bearer " + token)
+				.retrieve()
+				.toEntity(Void.class),
+			response
+		);
+	}
+
 	/** 문제 목록 조회 */
 	public ResponseEntity<PagedResponse<QuestonDto.Response>> getQuestionList(String accessToken, String refreshToken, int page, int size,
 		HttpServletResponse response) {

--- a/csalgo-web/src/main/java/kr/co/csalgo/web/admin/controller/AdminWebController.java
+++ b/csalgo-web/src/main/java/kr/co/csalgo/web/admin/controller/AdminWebController.java
@@ -4,7 +4,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -72,6 +74,16 @@ public class AdminWebController {
 		model.addAttribute("activeMenu", "users");
 
 		return "admin/dashboard/users";
+	}
+
+	@DeleteMapping("/users/{userId}")
+	public ResponseEntity<?> deleteUser(
+		@CookieValue("accessToken") String accessToken,
+		@CookieValue("refreshToken") String refreshToken,
+		@PathVariable Long userId,
+		HttpServletResponse httpServletResponse
+	) {
+		return adminService.deleteUser(accessToken, refreshToken, userId, httpServletResponse);
 	}
 
 	@GetMapping("/dashboard/questions")

--- a/csalgo-web/src/main/java/kr/co/csalgo/web/admin/service/AdminService.java
+++ b/csalgo-web/src/main/java/kr/co/csalgo/web/admin/service/AdminService.java
@@ -21,6 +21,10 @@ public class AdminService {
 		return adminRestClient.getUserList(accessToken, refreshToken, page, size, httpServletResponse);
 	}
 
+	public ResponseEntity<?> deleteUser(String accessToken, String refreshToken, Long userId, HttpServletResponse httpServletResponse) {
+		return adminRestClient.deleteUser(accessToken, refreshToken, userId, httpServletResponse);
+	}
+
 	public ResponseEntity<?> getQuestionList(String accessToken, String refreshToken, int page, int size, HttpServletResponse httpServletResponse) {
 		return adminRestClient.getQuestionList(accessToken, refreshToken, page, size, httpServletResponse);
 	}

--- a/csalgo-web/src/main/java/kr/co/csalgo/web/common/dto/MessageResponseDto.java
+++ b/csalgo-web/src/main/java/kr/co/csalgo/web/common/dto/MessageResponseDto.java
@@ -1,0 +1,16 @@
+package kr.co.csalgo.web.common.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MessageResponseDto {
+	private String message;
+
+	@Builder
+	public MessageResponseDto(String message) {
+		this.message = message;
+	}
+}

--- a/csalgo-web/src/main/resources/static/js/user-delete.js
+++ b/csalgo-web/src/main/resources/static/js/user-delete.js
@@ -1,0 +1,19 @@
+import {fetchWithOptions} from './http.js';
+
+async function deleteUser(userId) {
+    if (!confirm("정말로 삭제하시겠습니까?")) return;
+
+    const {ok, data} = await fetchWithOptions({
+        url: `/admin/users/${userId}`,
+        method: 'DELETE'
+    });
+
+    if (ok) {
+        alert("삭제 완료");
+        location.reload();
+    } else {
+        alert(data?.message || "삭제 실패");
+    }
+}
+
+window.deleteUser = deleteUser;

--- a/csalgo-web/src/main/resources/templates/admin/dashboard/users.html
+++ b/csalgo-web/src/main/resources/templates/admin/dashboard/users.html
@@ -13,11 +13,12 @@
             <th>UUID</th>
             <th>가입일</th>
             <th>수정일</th>
+            <th></th>
         </tr>
         </thead>
         <tbody>
-        <tr th:each="user, stat : ${users}">
-            <td th:text="${stat.count}">1</td>
+        <tr th:each="user : ${users}">
+            <td th:text="${user.id}">1</td>
             <td th:text="${user.email}">hong@test.com</td>
             <td>
         <span th:text="${user.role}"
@@ -31,6 +32,10 @@
             <td th:text="${user.uuid}">3c2e82ad-2951-4a63-8123-c975c7b50a55</td>
             <td th:text="${#temporals.format(user.createdAt, 'yyyy-MM-dd HH:mm')}">2025-08-20 12:00</td>
             <td th:text="${#temporals.format(user.updatedAt, 'yyyy-MM-dd HH:mm')}">2025-08-20 12:30</td>
+            <td>
+                <button class="btn btn-danger btn-sm" th:onclick="|deleteUser(${user.id})|">삭제</button>
+            </td>
+            <script type="module" src="/js/user-delete.js"></script>
         </tr>
         </tbody>
     </table>


### PR DESCRIPTION
<!-- (title: "[Type] Title close #IssueNumber") -->

## Motivation

<!-- 작성 배경 -->

- resolve #195 

## Problem Solving

<!-- 해결 방법 -->

- 사용자 삭제를 위한 Java 로직 구현
  - `AdminRestClient.deleteUser` (80ccf9bf82b2bbd1499e7595e83ccd3103ddd798)
  - `AdminService.deleteUser` (652490aa211e04f3bec622b2368ba8729933ec75)
  - `AdminWebController.deleteUser` (3619e82bf74ad9307bc9a0ed0ec729e681d55815)
  - `MessageResponseDto`: ResponseBody에 `messsage` 필드만 존재하는 응답(삭제, 수정 등)을 처리하기 위한 DTO 추가 (046e7237344752105f58ebbb225653c48daacce3)
- 관리자 페이지 코드 수정
  - `users.html`: 삭제 버튼 및 `user-delete.js` 스크립트 태그 추가
  - `user-delete.js`: 관리자 삭제 API 호출을 위한 js 파일

## To Reviewer

<!-- 리뷰어에게 말하고 싶은 것, 유의 깊게 봐주었으면 하는 것, 의문점 등 -->

### 🎨 사용자 목록 페이지 UI (삭제 버튼 추가)

<img width="1920" height="1055" alt="image" src="https://github.com/user-attachments/assets/5e17c2d6-986c-4fa2-850c-ed47e442bd58" />

- 삭제 기능 동작 여부는 Local에서 확인했습니다. (이메일 노출을 방지하기 위해 영상은 생략하겠습니다.)