### PR TITLE
[Feature] 어드민 페이지 문제 삭제 기능 연동 #197

### DIFF
--- a/csalgo-web/src/main/java/kr/co/csalgo/web/admin/client/AdminRestClient.java
+++ b/csalgo-web/src/main/java/kr/co/csalgo/web/admin/client/AdminRestClient.java
@@ -16,6 +16,7 @@ import kr.co.csalgo.web.admin.dto.AdminLoginDto;
 import kr.co.csalgo.web.admin.dto.AdminRefreshDto;
 import kr.co.csalgo.web.admin.dto.QuestonDto;
 import kr.co.csalgo.web.admin.dto.UserDto;
+import kr.co.csalgo.web.common.dto.MessageResponseDto;
 import kr.co.csalgo.web.common.dto.PagedResponse;
 import lombok.RequiredArgsConstructor;
 
@@ -70,6 +71,20 @@ public class AdminRestClient {
 				.retrieve()
 				.toEntity(new ParameterizedTypeReference<PagedResponse<QuestonDto.Response>>() {
 				}),
+			response
+		);
+	}
+
+	/** 문제 삭제 */
+	public ResponseEntity<MessageResponseDto> deleteQuestion(String accessToken, String refreshToken, Long questionId, HttpServletResponse response) {
+		return executeWithRetry(
+			accessToken,
+			refreshToken,
+			token -> restClient.delete()
+				.uri("/questions/{id}", questionId)
+				.header("Authorization", "Bearer " + token)
+				.retrieve()
+				.toEntity(MessageResponseDto.class),
 			response
 		);
 	}

--- a/csalgo-web/src/main/java/kr/co/csalgo/web/admin/controller/AdminWebController.java
+++ b/csalgo-web/src/main/java/kr/co/csalgo/web/admin/controller/AdminWebController.java
@@ -4,7 +4,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -95,6 +97,16 @@ public class AdminWebController {
 		model.addAttribute("activeMenu", "questions");
 
 		return "admin/dashboard/questions";
+	}
+
+	@DeleteMapping("/questions/{questionId}")
+	public ResponseEntity<?> deleteQuestion(
+		@CookieValue("accessToken") String accessToken,
+		@CookieValue("refreshToken") String refreshToken,
+		@PathVariable Long questionId,
+		HttpServletResponse httpServletResponse
+	) {
+		return adminService.deleteQuestion(accessToken, refreshToken, questionId, httpServletResponse);
 	}
 
 	@PostMapping("/login")

--- a/csalgo-web/src/main/java/kr/co/csalgo/web/admin/service/AdminService.java
+++ b/csalgo-web/src/main/java/kr/co/csalgo/web/admin/service/AdminService.java
@@ -24,5 +24,9 @@ public class AdminService {
 	public ResponseEntity<?> getQuestionList(String accessToken, String refreshToken, int page, int size, HttpServletResponse httpServletResponse) {
 		return adminRestClient.getQuestionList(accessToken, refreshToken, page, size, httpServletResponse);
 	}
+
+	public ResponseEntity<?> deleteQuestion(String accessToken, String refreshToken, Long questionId, HttpServletResponse httpServletResponse) {
+		return adminRestClient.deleteQuestion(accessToken, refreshToken, questionId, httpServletResponse);
+	}
 }
 

--- a/csalgo-web/src/main/java/kr/co/csalgo/web/common/dto/MessageResponseDto.java
+++ b/csalgo-web/src/main/java/kr/co/csalgo/web/common/dto/MessageResponseDto.java
@@ -1,0 +1,16 @@
+package kr.co.csalgo.web.common.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MessageResponseDto {
+	private String message;
+
+	@Builder
+	public MessageResponseDto(String message) {
+		this.message = message;
+	}
+}

--- a/csalgo-web/src/main/resources/static/css/style.css
+++ b/csalgo-web/src/main/resources/static/css/style.css
@@ -98,3 +98,8 @@ section {
 .admin-content {
     background-color: #fff;
 }
+
+.col-action {
+    min-width: 50px;
+    text-align: center;
+}

--- a/csalgo-web/src/main/resources/static/js/question-delete.js
+++ b/csalgo-web/src/main/resources/static/js/question-delete.js
@@ -1,0 +1,19 @@
+import {fetchWithOptions} from './http.js';
+
+async function deleteQuestion(questionId) {
+    if (!confirm("정말로 삭제하시겠습니까?")) return;
+
+    const {ok, data} = await fetchWithOptions({
+        url: `/admin/questions/${questionId}`,
+        method: 'DELETE'
+    });
+
+    if (ok) {
+        alert("삭제 완료");
+        location.reload();
+    } else {
+        alert(data?.message || "삭제 실패");
+    }
+}
+
+window.deleteQuestion = deleteQuestion;

--- a/csalgo-web/src/main/resources/templates/admin/dashboard/questions.html
+++ b/csalgo-web/src/main/resources/templates/admin/dashboard/questions.html
@@ -3,7 +3,6 @@
 <div th:fragment="contentFragment">
     <h3 class="fw-bold mb-4">문제 관리</h3>
     <p class="text-muted">문제 목록을 조회하고 관리할 수 있습니다.</p>
-
     <table class="table table-hover">
         <thead>
         <tr>
@@ -13,16 +12,20 @@
             <th>모범답안</th>
             <th>작성일</th>
             <th>수정일</th>
+            <th></th>
         </tr>
         </thead>
         <tbody>
-        <tr th:each="question, stat : ${questions}">
+        <tr th:each="question : ${questions}">
             <td th:text="${question.id}">1</td>
             <td th:text="${question.title}">문제 제목</td>
             <td th:text="${question.description}">문제 설명</td>
             <td th:text="${question.solution}">모범답안</td>
             <td th:text="${#temporals.format(question.createdAt, 'yyyy-MM-dd HH:mm')}">2025-08-20 12:00</td>
             <td th:text="${#temporals.format(question.updatedAt, 'yyyy-MM-dd HH:mm')}">2025-08-20 12:30</td>
+            <td>
+                <button class="btn btn-danger btn-sm col-action" th:onclick="|deleteQuestion(${question.id})|">삭제</button>
+            </td>
         </tr>
         </tbody>
     </table>
@@ -48,5 +51,6 @@
             </li>
         </ul>
     </nav>
+    <script type="module" src="/js/question-delete.js"></script>
 </div>
 </html>


### PR DESCRIPTION
<!-- (title: "[Type] Title close #IssueNumber") -->

## Motivation

<!-- 작성 배경 -->

- resolve #197 

## Problem Solving

<!-- 해결 방법 -->

- 문제 삭제를 위한 Java 로직 구현
  - `AdminRestClient.deleteQuestion` (fde621ab43166e28f0e4b43f8ca0a9bcce2cb12e)
  - `AdminService.deleteQuestion` (c556c8266590fb2c25e5e7a2e960ee3c660db294)
  - `AdminWebController.deleteQuestion` (6cc22a8a6cf67f0092507d834520985d52df5157)
  - `MessageResponseDto`: ResponseBody에 `messsage` 필드만 존재하는 응답(삭제, 수정 등)을 처리하기 위한 DTO 추가 (이전 PR과 동일) (0f335ac2bcab957710de773cf746f9744da50b5e)
- 관리자 페이지 코드 수정
  - `questions.html`: 삭제 버튼 및 `question-delete.js` 스크립트 태그 추가
  - `question-delete.js`: 문제 삭제 API 호출을 위한 js 파일

## To Reviewer

<!-- 리뷰어에게 말하고 싶은 것, 유의 깊게 봐주었으면 하는 것, 의문점 등 -->

### 🎨 문제 목록 페이지 UI (삭제 버튼 추가)

<img width="600" height="1055" alt="image" src="https://github.com/user-attachments/assets/bc2fba89-b595-4dba-91de-66a1ddd764d8" />

#### 삭제 후 DB 상태

<img width="1349" height="59" alt="image" src="https://github.com/user-attachments/assets/c03a9637-f03c-488a-a7bf-585f4350bb4c" />

#### 삭제 시 Alert 창

<img width="200" height="144" alt="image" src="https://github.com/user-attachments/assets/5ef37d69-c12c-417c-8855-eaa8ad412054" />