### PR TITLE
[Feature] User 엔티티 email 인덱스 추가 및 성능 비교 #181

### DIFF
--- a/csalgo-domain/src/main/java/kr/co/csalgo/domain/user/entity/User.java
+++ b/csalgo-domain/src/main/java/kr/co/csalgo/domain/user/entity/User.java
@@ -9,6 +9,8 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
 import kr.co.csalgo.domain.common.entity.AuditableEntity;
 import kr.co.csalgo.domain.user.type.Role;
 import lombok.Builder;
@@ -20,6 +22,9 @@ import lombok.NoArgsConstructor;
 @Getter
 @SQLDelete(sql = "UPDATE user SET deleted_at = NOW() WHERE id = ?")
 @SQLRestriction("deleted_at IS NULL")
+@Table(name = "USER", indexes = {
+	@Index(name = "idx_user_email", columnList = "email")
+})
 public class User extends AuditableEntity {
 
 	@Column(nullable = false, length = 100)


### PR DESCRIPTION
<!-- (title: "[Type] Title close #IssueNumber") -->

## Motivation

<!-- 작성 배경 -->

- resolve #181 

## Problem Solving

<!-- 해결 방법 -->

- `User.email` 컬럼에 인덱스 제약 조건을 추가하여 이메일 기반 조회 성능을 개선
- 대량 더미 데이터(약 100,000건)를 삽입 후 조회 쿼리 실행
```sql
EXPLAIN ANALYZE SELECT * 
FROM user 
WHERE email = 'user99999@example.com';

```

## To Reviewer

<!-- 리뷰어에게 말하고 싶은 것, 유의 깊게 봐주었으면 하는 것, 의문점 등 -->
| Table scan | Index lookup|
|--|--|
| <img width="1177" height="142" alt="image" src="https://github.com/user-attachments/assets/61c3dee8-0a9c-44d4-a016-009d5294e7fd" /> | <img width="1438" height="115" alt="image" src="https://github.com/user-attachments/assets/a32238bf-ffdd-4e22-a732-2347993b83fb" /> |

- 아래는 성능 비교 결과입니다. (10만 건 기준)

| 구분 | 실행 계획 | rows | 실행 시간 |
|------|-----------|------|------------|
| 인덱스 적용 전 | Table scan | 100,001 | 약 68ms |
| 인덱스 적용 후 | Index lookup | 1 | 약 0.038ms |

- 결과를 보면 인덱스를 적용한 경우에는 `rows=1`, 실행 시간 약 **0.038ms**로 매우 빠르게 조회되는 것을 확인할 수 있습니다.  
- 반면 인덱스가 없을 때는 `rows=100,001`, 실행 시간 약 **68ms**로 전체 테이블을 스캔해야 했습니다.  
- 성능 개선율은 약 **99.94%** 으로, 이메일 기반 조회에서 인덱스 적용이 조회 성능에 유의미한 효과를 보임을 확인했습니다.
- 운영 환경에서는 수백만 건 단위에서도 동일한 효과가 있을 것으로 예상됩니다.
> 이미 운영 환경 db가 존재하는 상태이므로, 머지 후 db에 따로 create index 설정을 진행하겠습니다.