### PR TITLE
[Feature] 어드민 페이지 문제 상세 조회 및 수정 기능 구현 #132, #196

### DIFF
--- a/csalgo-application/src/main/java/kr/co/csalgo/application/problem/usecase/UpdateQuestionUseCase.java
+++ b/csalgo-application/src/main/java/kr/co/csalgo/application/problem/usecase/UpdateQuestionUseCase.java
@@ -3,6 +3,7 @@ package kr.co.csalgo.application.problem.usecase;
 import org.springframework.stereotype.Service;
 
 import kr.co.csalgo.application.problem.dto.QuestionDto;
+import kr.co.csalgo.common.message.CommonResponse;
 import kr.co.csalgo.common.message.MessageCode;
 import kr.co.csalgo.domain.question.service.QuestionService;
 import lombok.RequiredArgsConstructor;
@@ -14,8 +15,8 @@ import lombok.extern.slf4j.Slf4j;
 public class UpdateQuestionUseCase {
 	private final QuestionService questionService;
 
-	public String updateQuestion(Long questionId, QuestionDto.Request request) {
+	public CommonResponse updateQuestion(Long questionId, QuestionDto.Request request) {
 		questionService.update(questionId, request.getTitle(), request.getSolution());
-		return MessageCode.UPDATE_QUESTION_SUCCESS.getMessage();
+		return new CommonResponse(MessageCode.UPDATE_QUESTION_SUCCESS.getMessage());
 	}
 }

--- a/csalgo-application/src/test/java/kr/co/csalgo/application/problem/usecase/UpdateQuestionUseCaseTest.java
+++ b/csalgo-application/src/test/java/kr/co/csalgo/application/problem/usecase/UpdateQuestionUseCaseTest.java
@@ -11,7 +11,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import kr.co.csalgo.application.problem.dto.QuestionDto;
-import kr.co.csalgo.common.message.MessageCode;
+import kr.co.csalgo.common.message.CommonResponse;
 import kr.co.csalgo.domain.question.service.QuestionService;
 
 @ExtendWith(MockitoExtension.class)
@@ -35,9 +35,9 @@ class UpdateQuestionUseCaseTest {
 
 		doNothing().when(questionService).update(questionId, request.getTitle(), request.getSolution());
 
-		String result = updateQuestionUseCase.updateQuestion(questionId, request);
+		CommonResponse result = updateQuestionUseCase.updateQuestion(questionId, request);
 
 		verify(questionService).update(questionId, "수정된 제목", "수정된 풀이");
-		assertThat(result).isEqualTo(MessageCode.UPDATE_QUESTION_SUCCESS.getMessage());
+		assertThat(result).isNotNull();
 	}
 }

--- a/csalgo-server/src/main/java/kr/co/csalgo/server/question/QuestionController.java
+++ b/csalgo-server/src/main/java/kr/co/csalgo/server/question/QuestionController.java
@@ -1,6 +1,5 @@
 package kr.co.csalgo.server.question;
 
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -73,8 +72,7 @@ public class QuestionController {
 	@Operation(summary = "문제 수정", description = "관리자는 문제를 수정할 수 있습니다.")
 	@ApiResponse(responseCode = "200", description = "문제 수정 성공")
 	public ResponseEntity<?> questionUpdate(@PathVariable Long questionId, @RequestBody QuestionDto.Request request) {
-		String message = updateQuestionUseCase.updateQuestion(questionId, request);
-		return ResponseEntity.status(HttpStatus.OK).body(message);
+		return ResponseEntity.ok(updateQuestionUseCase.updateQuestion(questionId, request));
 	}
 
 	@DeleteMapping("/{questionId}")

--- a/csalgo-server/src/test/java/kr/co/csalgo/server/question/QuestionControllerTest.java
+++ b/csalgo-server/src/test/java/kr/co/csalgo/server/question/QuestionControllerTest.java
@@ -188,13 +188,12 @@ class QuestionControllerTest {
 				.build()
 		);
 		when(updateQuestionUseCase.updateQuestion(eq(questionId), any(QuestionDto.Request.class)))
-			.thenReturn(MessageCode.UPDATE_QUESTION_SUCCESS.getMessage());
+			.thenReturn(new CommonResponse(MessageCode.UPDATE_QUESTION_SUCCESS.getMessage()));
 
 		mockMvc.perform(put("/api/questions/{questionId}", questionId)
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(body))
-			.andExpect(status().isOk())
-			.andExpect(content().string(MessageCode.UPDATE_QUESTION_SUCCESS.getMessage()));
+			.andExpect(status().isOk());
 
 	}
 

--- a/csalgo-web/src/main/java/kr/co/csalgo/web/admin/client/AdminRestClient.java
+++ b/csalgo-web/src/main/java/kr/co/csalgo/web/admin/client/AdminRestClient.java
@@ -89,6 +89,37 @@ public class AdminRestClient {
 		);
 	}
 
+	/** 문제 상세 조회 */
+	public ResponseEntity<QuestonDto.Response> getQuestionDetail(String accessToken, String refreshToken, Long questionId,
+		HttpServletResponse response) {
+		return executeWithRetry(
+			accessToken,
+			refreshToken,
+			token -> restClient.get()
+				.uri("/questions/{id}", questionId)
+				.header("Authorization", "Bearer " + token)
+				.retrieve()
+				.toEntity(QuestonDto.Response.class),
+			response
+		);
+	}
+
+	/** 문제 수정 */
+	public ResponseEntity<MessageResponseDto> updateQuestion(String accessToken, String refreshToken, Long questionId, QuestonDto.Request body,
+		HttpServletResponse response) {
+		return executeWithRetry(
+			accessToken,
+			refreshToken,
+			token -> restClient.put()
+				.uri("/questions/{id}", questionId)
+				.header("Authorization", "Bearer " + token)
+				.body(body)
+				.retrieve()
+				.toEntity(MessageResponseDto.class),
+			response
+		);
+	}
+
 	/** 문제 삭제 */
 	public ResponseEntity<MessageResponseDto> deleteQuestion(String accessToken, String refreshToken, Long questionId, HttpServletResponse response) {
 		return executeWithRetry(

--- a/csalgo-web/src/main/java/kr/co/csalgo/web/admin/controller/AdminWebController.java
+++ b/csalgo-web/src/main/java/kr/co/csalgo/web/admin/controller/AdminWebController.java
@@ -8,6 +8,8 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
@@ -124,6 +126,17 @@ public class AdminWebController {
 		model.addAttribute("activeMenu", "questions");
 
 		return "admin/dashboard/question";
+	}
+
+	@PutMapping("/questions/{questionId}")
+	public ResponseEntity<?> updateQuestion(
+		@CookieValue("accessToken") String accessToken,
+		@CookieValue("refreshToken") String refreshToken,
+		@PathVariable Long questionId,
+		@RequestBody QuestonDto.Request request,
+		HttpServletResponse httpServletResponse
+	) {
+		return adminService.updateQuestion(accessToken, refreshToken, questionId, request, httpServletResponse);
 	}
 
 	@DeleteMapping("/questions/{questionId}")

--- a/csalgo-web/src/main/java/kr/co/csalgo/web/admin/controller/AdminWebController.java
+++ b/csalgo-web/src/main/java/kr/co/csalgo/web/admin/controller/AdminWebController.java
@@ -109,6 +109,23 @@ public class AdminWebController {
 		return "admin/dashboard/questions";
 	}
 
+	@GetMapping("/dashboard/questions/{questionId}")
+	public String questionDetail(
+		@CookieValue("accessToken") String accessToken,
+		@CookieValue("refreshToken") String refreshToken,
+		@PathVariable Long questionId,
+		HttpServletResponse httpServletResponse,
+		Model model
+	) {
+		ResponseEntity<?> response = adminService.getQuestion(accessToken, refreshToken, questionId, httpServletResponse);
+		QuestonDto.Response body = (QuestonDto.Response)response.getBody();
+
+		model.addAttribute("question", body);
+		model.addAttribute("activeMenu", "questions");
+
+		return "admin/dashboard/question";
+	}
+
 	@DeleteMapping("/questions/{questionId}")
 	public ResponseEntity<?> deleteQuestion(
 		@CookieValue("accessToken") String accessToken,

--- a/csalgo-web/src/main/java/kr/co/csalgo/web/admin/dto/QuestonDto.java
+++ b/csalgo-web/src/main/java/kr/co/csalgo/web/admin/dto/QuestonDto.java
@@ -9,6 +9,21 @@ import lombok.NoArgsConstructor;
 public class QuestonDto {
 	@Getter
 	@NoArgsConstructor
+	public static class Request {
+		private String title;
+		private String description;
+		private String solution;
+
+		@Builder
+		public Request(String title, String description, String solution) {
+			this.title = title;
+			this.description = description;
+			this.solution = solution;
+		}
+	}
+
+	@Getter
+	@NoArgsConstructor
 	public static class Response {
 		private Long id;
 		private String title;

--- a/csalgo-web/src/main/java/kr/co/csalgo/web/admin/service/AdminService.java
+++ b/csalgo-web/src/main/java/kr/co/csalgo/web/admin/service/AdminService.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service;
 import jakarta.servlet.http.HttpServletResponse;
 import kr.co.csalgo.web.admin.client.AdminRestClient;
 import kr.co.csalgo.web.admin.dto.AdminLoginDto;
+import kr.co.csalgo.web.admin.dto.QuestonDto;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -27,6 +28,15 @@ public class AdminService {
 
 	public ResponseEntity<?> getQuestionList(String accessToken, String refreshToken, int page, int size, HttpServletResponse httpServletResponse) {
 		return adminRestClient.getQuestionList(accessToken, refreshToken, page, size, httpServletResponse);
+	}
+
+	public ResponseEntity<?> getQuestion(String accessToken, String refreshToken, Long questionId, HttpServletResponse httpServletResponse) {
+		return adminRestClient.getQuestionDetail(accessToken, refreshToken, questionId, httpServletResponse);
+	}
+
+	public ResponseEntity<?> updateQuestion(String accessToken, String refreshToken, Long questionId, QuestonDto.Request request,
+		HttpServletResponse httpServletResponse) {
+		return adminRestClient.updateQuestion(accessToken, refreshToken, questionId, request, httpServletResponse);
 	}
 
 	public ResponseEntity<?> deleteQuestion(String accessToken, String refreshToken, Long questionId, HttpServletResponse httpServletResponse) {

--- a/csalgo-web/src/main/resources/static/js/question-delete.js
+++ b/csalgo-web/src/main/resources/static/js/question-delete.js
@@ -10,7 +10,7 @@ async function deleteQuestion(questionId) {
 
     if (ok) {
         alert("삭제 완료");
-        location.reload();
+        window.location.href = "/admin/dashboard/questions";
     } else {
         alert(data?.message || "삭제 실패");
     }

--- a/csalgo-web/src/main/resources/static/js/question-update.js
+++ b/csalgo-web/src/main/resources/static/js/question-update.js
@@ -1,0 +1,27 @@
+import {fetchWithOptions} from './http.js';
+
+async function updateQuestion(questionId) {
+    const payload = {
+        title: document.getElementById('titleInput').value,
+        description: document.getElementById('descInput').value,
+        solution: document.getElementById('solutionInput').value
+    };
+
+    const {ok, data} = await fetchWithOptions({
+        url: `/admin/questions/${questionId}`,
+        method: 'PUT',
+        body: payload,
+        headers: {
+            'Content-Type': 'application/json'
+        }
+    });
+
+    if (ok) {
+        alert("수정 완료");
+        window.location.reload();
+    } else {
+        alert(data?.message || "수정 실패");
+    }
+}
+
+window.updateQuestion = updateQuestion;

--- a/csalgo-web/src/main/resources/templates/admin/dashboard/question.html
+++ b/csalgo-web/src/main/resources/templates/admin/dashboard/question.html
@@ -1,0 +1,59 @@
+<html xmlns:th="http://www.thymeleaf.org"
+      th:replace="~{admin/dashboard/layout :: layout(~{::contentFragment})}">
+<div th:fragment="contentFragment">
+    <h3 class="fw-bold mb-4">문제 상세</h3>
+    <p class="text-muted">문제의 상세 내용을 확인할 수 있습니다.</p>
+
+    <div class="card shadow-sm">
+        <div class="card-body">
+            <div class="d-flex justify-content-between align-items-center mb-3">
+                <h4 id="titleDisplay" class="card-title fw-bold mb-0" th:text="${question.title}">문제 제목</h4>
+                <input id="titleInput" class="form-control d-none" type="text" th:value="${question.title}">
+                <button class="btn btn-sm btn-outline-secondary" type="button"
+                        onclick="toggleEdit('title')">✏️</button>
+            </div>
+
+            <div class="text-muted small mb-4">
+                <div>문제 ID: <span th:text="${question.id}">1</span></div>
+                <div>작성일: <span th:text="${#temporals.format(question.createdAt, 'yyyy-MM-dd HH:mm')}">2025-08-16</span></div>
+                <div>수정일: <span th:text="${#temporals.format(question.updatedAt, 'yyyy-MM-dd HH:mm')}">2025-08-16</span></div>
+            </div>
+
+            <div class="mb-4">
+                <div class="d-flex justify-content-between align-items-center mb-1">
+                    <h6 class="fw-semibold mb-0">설명</h6>
+                    <button class="btn btn-sm btn-outline-secondary" type="button"
+                            onclick="toggleEdit('desc')">✏️</button>
+                </div>
+                <p id="descDisplay" style="white-space: pre-wrap; min-height: 2rem;"
+                   th:text="${question.description}"> </p>
+                <textarea id="descInput" class="form-control d-none" rows="5"
+                          th:text="${question.description}"></textarea>
+            </div>
+
+            <div class="mb-4">
+                <div class="d-flex justify-content-between align-items-center mb-1">
+                    <h6 class="fw-semibold mb-0">모범답안</h6>
+                    <button class="btn btn-sm btn-outline-secondary" type="button"
+                            onclick="toggleEdit('solution')">✏️</button>
+                </div>
+                <pre id="solutionDisplay" class="bg-light p-3 rounded" style="white-space: pre-wrap; min-height: 2rem;"
+                     th:text="${question.solution}"> </pre>
+                <textarea id="solutionInput" class="form-control d-none" rows="7"
+                          th:text="${question.solution}"></textarea>
+            </div>
+        </div>
+
+        <div class="card-footer d-flex justify-content-between bg-white">
+            <a th:href="@{/admin/dashboard/questions}" class="btn btn-secondary">목록</a>
+            <div class="d-flex gap-2">
+                <button class="btn btn-primary" type="button"
+                        onclick="saveQuestion([[${question.id}]])">저장</button>
+                <button class="btn btn-danger" type="button"
+                        th:onclick="|deleteQuestion(${question.id})|">삭제</button>
+            </div>
+        </div>
+    </div>
+    <script type="module" src="/js/question-delete.js"></script>
+</div>
+</html>

--- a/csalgo-web/src/main/resources/templates/admin/dashboard/question.html
+++ b/csalgo-web/src/main/resources/templates/admin/dashboard/question.html
@@ -10,7 +10,8 @@
                 <h4 id="titleDisplay" class="card-title fw-bold mb-0" th:text="${question.title}">문제 제목</h4>
                 <input id="titleInput" class="form-control d-none" type="text" th:value="${question.title}">
                 <button class="btn btn-sm btn-outline-secondary" type="button"
-                        onclick="toggleEdit('title')">✏️</button>
+                        onclick="toggleEdit('title')">✏️
+                </button>
             </div>
 
             <div class="text-muted small mb-4">
@@ -23,10 +24,11 @@
                 <div class="d-flex justify-content-between align-items-center mb-1">
                     <h6 class="fw-semibold mb-0">설명</h6>
                     <button class="btn btn-sm btn-outline-secondary" type="button"
-                            onclick="toggleEdit('desc')">✏️</button>
+                            onclick="toggleEdit('desc')">✏️
+                    </button>
                 </div>
                 <p id="descDisplay" style="white-space: pre-wrap; min-height: 2rem;"
-                   th:text="${question.description}"> </p>
+                   th:text="${question.description}"></p>
                 <textarea id="descInput" class="form-control d-none" rows="5"
                           th:text="${question.description}"></textarea>
             </div>
@@ -35,7 +37,8 @@
                 <div class="d-flex justify-content-between align-items-center mb-1">
                     <h6 class="fw-semibold mb-0">모범답안</h6>
                     <button class="btn btn-sm btn-outline-secondary" type="button"
-                            onclick="toggleEdit('solution')">✏️</button>
+                            onclick="toggleEdit('solution')">✏️
+                    </button>
                 </div>
                 <pre id="solutionDisplay" class="bg-light p-3 rounded" style="white-space: pre-wrap; min-height: 2rem;"
                      th:text="${question.solution}"> </pre>
@@ -48,12 +51,27 @@
             <a th:href="@{/admin/dashboard/questions}" class="btn btn-secondary">목록</a>
             <div class="d-flex gap-2">
                 <button class="btn btn-primary" type="button"
-                        onclick="saveQuestion([[${question.id}]])">저장</button>
+                        th:onclick="|updateQuestion(${question.id})|">저장
+                </button>
                 <button class="btn btn-danger" type="button"
-                        th:onclick="|deleteQuestion(${question.id})|">삭제</button>
+                        th:onclick="|deleteQuestion(${question.id})|">삭제
+                </button>
             </div>
         </div>
+
     </div>
+    <script type="module" src="/js/question-update.js"></script>
     <script type="module" src="/js/question-delete.js"></script>
+    <script>
+        function toggleEdit(field) {
+            const display = document.getElementById(field + 'Display');
+            const input = document.getElementById(field + 'Input');
+
+            if (display && input) {
+                display.classList.toggle('d-none');
+                input.classList.toggle('d-none');
+            }
+        }
+    </script>
 </div>
 </html>

--- a/csalgo-web/src/main/resources/templates/admin/dashboard/questions.html
+++ b/csalgo-web/src/main/resources/templates/admin/dashboard/questions.html
@@ -18,7 +18,10 @@
         <tbody>
         <tr th:each="question : ${questions}">
             <td th:text="${question.id}">1</td>
-            <td th:text="${question.title}">문제 제목</td>
+            <td>
+                <a th:href="@{/admin/dashboard/questions/{id}(id=${question.id})}"
+                   th:text="${question.title}">문제 제목</a>
+            </td>
             <td th:text="${question.description}">문제 설명</td>
             <td th:text="${question.solution}">모범답안</td>
             <td th:text="${#temporals.format(question.createdAt, 'yyyy-MM-dd HH:mm')}">2025-08-20 12:00</td>

--- a/csalgo-web/src/main/resources/templates/admin/dashboard/questions.html
+++ b/csalgo-web/src/main/resources/templates/admin/dashboard/questions.html
@@ -9,7 +9,6 @@
             <th>#</th>
             <th>문제 제목</th>
             <th>문제 설명</th>
-            <th>모범답안</th>
             <th>작성일</th>
             <th>수정일</th>
             <th></th>
@@ -18,16 +17,15 @@
         <tbody>
         <tr th:each="question : ${questions}">
             <td th:text="${question.id}">1</td>
-            <td>
-                <a th:href="@{/admin/dashboard/questions/{id}(id=${question.id})}"
-                   th:text="${question.title}">문제 제목</a>
-            </td>
+            <td th:text="${question.title}">문제 제목</td>
             <td th:text="${question.description}">문제 설명</td>
-            <td th:text="${question.solution}">모범답안</td>
             <td th:text="${#temporals.format(question.createdAt, 'yyyy-MM-dd HH:mm')}">2025-08-20 12:00</td>
             <td th:text="${#temporals.format(question.updatedAt, 'yyyy-MM-dd HH:mm')}">2025-08-20 12:30</td>
             <td>
-                <button class="btn btn-danger btn-sm col-action" th:onclick="|deleteQuestion(${question.id})|">삭제</button>
+                <a class="btn btn-primary btn-sm col-action"
+                   th:href="@{/admin/dashboard/questions/{id}(id=${question.id})}">
+                    자세히 보기
+                </a>
             </td>
         </tr>
         </tbody>


### PR DESCRIPTION
<!-- (title: "[Type] Title close #IssueNumber") -->

## Motivation

<!-- 작성 배경 -->

- resolves #132, #196 

## Problem Solving

<!-- 해결 방법 -->

- 문제 수정 기능을 위한 RestClient, Service, Controller 계층의 메서드를 추가하고 DTO를 정의함
- 관리자 페이지에서 문제 상세 조회 화면을 구현하여 문제 내용을 확인 및 수정할 수 있도록 개선함
- 수정 API의 응답을 기존 String → JSON DTO(MessageResponseDto)로 통일하여 클라이언트에서 일관성 있게 처리 가능하게 함
- 프론트엔드(JS) 함수로 문제 수정 기능을 구현하고 API와 연동함
- 문제 삭제 후 상세 페이지에서 404가 발생하던 문제를 수정하여 삭제 시 목록 페이지로 이동하도록 개선함
- 문제 목록 화면에서 삭제 버튼을 제거하고 "자세히 보기" 버튼으로 변경하여 UX를 개선하고 실수 방지를 유도함

## To Reviewer

<!-- 리뷰어에게 말하고 싶은 것, 유의 깊게 봐주었으면 하는 것, 의문점 등 -->

### 🎨 수정된 UI

| 문제 목록 페이지 | 문제 상세 조회 페이지 |
| --- | --- |
| <img width="1920" height="1055" alt="image" src="https://github.com/user-attachments/assets/7e29aeac-8580-4653-bb96-bb5a07260bbc" /> | <img width="1920" height="1055" alt="image" src="https://github.com/user-attachments/assets/5be63969-358e-4372-a569-5e89a10bd608" /> |