### PR TITLE
[Fix] 관리자 로그인 API 응답 JSON 보장 처리 #213

### DIFF
--- a/csalgo-web/src/main/java/kr/co/csalgo/web/admin/controller/AdminWebController.java
+++ b/csalgo-web/src/main/java/kr/co/csalgo/web/admin/controller/AdminWebController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
 
 import jakarta.servlet.http.HttpServletResponse;
 import kr.co.csalgo.web.admin.dto.QuestonDto;
@@ -96,6 +97,7 @@ public class AdminWebController {
 	}
 
 	@PutMapping("/users/{userId}/role")
+	@ResponseBody
 	public ResponseEntity<?> updateUserRole(
 		@CookieValue("accessToken") String accessToken,
 		@CookieValue("refreshToken") String refreshToken,
@@ -107,6 +109,7 @@ public class AdminWebController {
 	}
 
 	@DeleteMapping("/users/{userId}")
+	@ResponseBody
 	public ResponseEntity<?> deleteUser(
 		@CookieValue("accessToken") String accessToken,
 		@CookieValue("refreshToken") String refreshToken,
@@ -157,6 +160,7 @@ public class AdminWebController {
 	}
 
 	@PutMapping("/questions/{questionId}")
+	@ResponseBody
 	public ResponseEntity<?> updateQuestion(
 		@CookieValue("accessToken") String accessToken,
 		@CookieValue("refreshToken") String refreshToken,
@@ -168,6 +172,7 @@ public class AdminWebController {
 	}
 
 	@DeleteMapping("/questions/{questionId}")
+	@ResponseBody
 	public ResponseEntity<?> deleteQuestion(
 		@CookieValue("accessToken") String accessToken,
 		@CookieValue("refreshToken") String refreshToken,
@@ -178,6 +183,7 @@ public class AdminWebController {
 	}
 
 	@PostMapping("/login")
+	@ResponseBody
 	public ResponseEntity<?> login(@RequestParam String email, @RequestParam String password) {
 		return adminService.login(email, password);
 	}


### PR DESCRIPTION
<!-- (title: "[Type] Title close #IssueNumber") -->

## Motivation

<!-- 작성 배경 -->

- resolve #213 

## Problem Solving

* **문제 원인** (추정)
  * `AdminWebController.login` 메서드가 `@Controller`에 위치하면서 `@ResponseBody` 어노테이션이 누락됨
  * 로컬 환경에서는 `ResponseEntity<?>` 반환 시 JSON으로 직렬화되어 정상 동작했으나,
    배포 환경(Cloudflare)에서는 `Content-Type`이 `text/html`로 내려가거나 HTML 뷰 리졸버가 개입하는 경우 발생
  * 이로 인해 FE의 `res.json()` 파싱이 실패 → `"서버 통신 오류"` 발생하는 것으로 추정
* **해결 방안**
  * `@ResponseBody` 어노테이션을 명시하여 `/admin/login` 요청이 항상 JSON 응답을 보장하도록 수정
  * `/subscription/request-code` 등과 달리 `/admin/login`에서만 문제가 발생한 이유는, 전자에는 `@ResponseBody`가 이미 선언되어 있었기 때문임

## To Reviewer

* `Problem Solving`에서 언급했듯이 원인 추정을 통한 PR이기 때문에 별도 PR이 추가적으로 발생할 수 있습니다.