### PR TITLE
GPT Client Bean 생성 실패 해결 및 Terraform Secret 주입 반영 #238

### DIFF
--- a/csalgo-iac/main.tf
+++ b/csalgo-iac/main.tf
@@ -30,7 +30,9 @@ module "server" {
 
   sentry_dsn = var.sentry_dsn
   jwt_secret = var.jwt_secret
+
   huggingface_api_token = var.huggingface_api_token
+  openai_api_token = var.openai_api_token
 }
 
 module "web" {
@@ -62,6 +64,9 @@ module "scheduler" {
 
   sentry_dsn = var.sentry_dsn
   jwt_secret = var.jwt_secret
+
+  huggingface_api_token = var.huggingface_api_token
+  openai_api_token = var.openai_api_token
 }
 
 module "dns" {

--- a/csalgo-iac/modules/scheduler/main.tf
+++ b/csalgo-iac/modules/scheduler/main.tf
@@ -16,6 +16,8 @@ resource "kubernetes_secret" "csalgo_scheduler_env" {
     REDIS_HOST    = var.redis_host
     REDIS_PORT    = var.redis_port
     JWT_SECRET    = var.jwt_secret
+    HUGGINGFACE_API_TOKEN = var.huggingface_api_token
+    OPENAI_API_TOKEN = var.openai_api_token
   }
 
   type = "Opaque"
@@ -54,123 +56,9 @@ resource "kubernetes_deployment" "csalgo_scheduler" {
           name  = "csalgo-scheduler"
           image = var.image
 
-          env {
-            name = "MAIL_HOST"
-            value_from {
-              secret_key_ref {
-                name = kubernetes_secret.csalgo_scheduler_env.metadata[0].name
-                key  = "MAIL_HOST"
-              }
-            }
-          }
-
-          env {
-            name = "MAIL_PORT"
-            value_from {
-              secret_key_ref {
-                name = kubernetes_secret.csalgo_scheduler_env.metadata[0].name
-                key  = "MAIL_PORT"
-              }
-            }
-          }
-
-          env {
-            name = "MAIL_USERNAME"
-            value_from {
-              secret_key_ref {
-                name = kubernetes_secret.csalgo_scheduler_env.metadata[0].name
-                key  = "MAIL_USERNAME"
-              }
-            }
-          }
-
-          env {
-            name = "MAIL_PASSWORD"
-            value_from {
-              secret_key_ref {
-                name = kubernetes_secret.csalgo_scheduler_env.metadata[0].name
-                key  = "MAIL_PASSWORD"
-              }
-            }
-          }
-
-          env {
-            name = "DB_HOST"
-            value_from {
-              secret_key_ref {
-                name = kubernetes_secret.csalgo_scheduler_env.metadata[0].name
-                key  = "DB_HOST"
-              }
-            }
-          }
-
-          env {
-            name = "DB_NAME"
-            value_from {
-              secret_key_ref {
-                name = kubernetes_secret.csalgo_scheduler_env.metadata[0].name
-                key  = "DB_NAME"
-              }
-            }
-          }
-
-          env {
-            name = "DB_USERNAME"
-            value_from {
-              secret_key_ref {
-                name = kubernetes_secret.csalgo_scheduler_env.metadata[0].name
-                key  = "DB_USERNAME"
-              }
-            }
-          }
-
-          env {
-            name = "DB_PASSWORD"
-            value_from {
-              secret_key_ref {
-                name = kubernetes_secret.csalgo_scheduler_env.metadata[0].name
-                key  = "DB_PASSWORD"
-              }
-            }
-          }
-
-          env {
-            name = "SENTRY_DSN"
-            value_from {
-              secret_key_ref {
-                name = kubernetes_secret.csalgo_scheduler_env.metadata[0].name
-                key  = "SENTRY_DSN"
-              }
-            }
-          }
-
-          env {
-            name = "REDIS_HOST"
-            value_from {
-              secret_key_ref {
-                name = kubernetes_secret.csalgo_scheduler_env.metadata[0].name
-                key  = "REDIS_HOST"
-              }
-            }
-          }
-
-          env {
-            name = "REDIS_PORT"
-            value_from {
-              secret_key_ref {
-                name = kubernetes_secret.csalgo_scheduler_env.metadata[0].name
-                key  = "REDIS_PORT"
-              }
-            }
-          }
-
-          env {
-            name = "JWT_SECRET"
-            value_from {
-              secret_key_ref {
-                name = kubernetes_secret.csalgo_scheduler_env.metadata[0].name
-                key  = "JWT_SECRET"
-              }
+          env_from {
+            secret_ref {
+              name = kubernetes_secret.csalgo_scheduler_env.metadata[0].name
             }
           }
 

--- a/csalgo-iac/modules/scheduler/variables.tf
+++ b/csalgo-iac/modules/scheduler/variables.tf
@@ -74,3 +74,15 @@ variable "jwt_secret" {
   type        = string
   sensitive   = true
 }
+
+variable "huggingface_api_token" {
+  description = "Huggingface API Token"
+  type        = string
+  sensitive   = true
+}
+
+variable "openai_api_token" {
+  description = "OpenAI API Token"
+  type        = string
+  sensitive   = true
+}

--- a/csalgo-iac/modules/server/main.tf
+++ b/csalgo-iac/modules/server/main.tf
@@ -17,6 +17,7 @@ resource "kubernetes_secret" "csalgo_server_env" {
     REDIS_PORT    = var.redis_port
     JWT_SECRET    = var.jwt_secret
     HUGGINGFACE_API_TOKEN = var.huggingface_api_token
+    OPENAI_API_TOKEN = var.openai_api_token
   }
 
   type = "Opaque"

--- a/csalgo-iac/modules/server/variables.tf
+++ b/csalgo-iac/modules/server/variables.tf
@@ -80,3 +80,9 @@ variable "huggingface_api_token" {
   type        = string
   sensitive   = true
 }
+
+variable "openai_api_token" {
+  description = "OpenAI API 토큰"
+  type        = string
+  sensitive   = true
+}

--- a/csalgo-iac/variables.tf
+++ b/csalgo-iac/variables.tf
@@ -81,6 +81,12 @@ variable "huggingface_api_token" {
   sensitive   = true
 }
 
+variable "openai_api_token" {
+  description = "OpenAI API Token"
+  type        = string
+  sensitive   = true
+}
+
 variable "server_image" {
   type = string
   default = "csalgo.kr.ncr.ntruss.com/csalgo-server:latest"

--- a/csalgo-scheduler/src/main/resources/application.yml
+++ b/csalgo-scheduler/src/main/resources/application.yml
@@ -69,3 +69,7 @@ external:
   resources:
     usage-url: ${USAGE_GUIDE_URL:https://kr.object.ncloudstorage.com/contest34-bucket-priv/resources/usage.html}
     images-url: ${IMAGE_BASE_URL:https://kr.object.ncloudstorage.com/contest34-bucket-priv/resources/images}
+
+openai:
+  token: ${OPENAI_API_TOKEN:dummy-token}
+  model: ${OPENAI_MODEL:gpt-4o-mini}


### PR DESCRIPTION
<!-- (title: "[Type] Title close #IssueNumber") -->

## Motivation

<!-- 작성 배경 -->

- resolve #238 

## Problem Solving

* `gptClient` 빈 생성 과정에서 `openai.token` 프로퍼티가 누락되어 `ApplicationContext` 초기화 실패 발생
* 해결 방안:
  * `application.yml`에 `openai.token` 속성 정의 추가
  * Kubernetes/Terraform 배포 시 `OPENAI_TOKEN` 환경 변수가 Secret을 통해 주입되도록 수정
  * Terraform `kubernetes_secret` 및 `deployment` 모듈 수정 → `openai.token` 값이 Pod 환경변수에 주입되도록 반영

## To Reviewer

- 없음