### PR TITLE
[Fix] 관리자 로그인 실패 오류 해결 #213

### DIFF
--- a/csalgo-web/src/main/java/kr/co/csalgo/web/admin/client/AdminRestClient.java
+++ b/csalgo-web/src/main/java/kr/co/csalgo/web/admin/client/AdminRestClient.java
@@ -214,9 +214,10 @@ public class AdminRestClient {
 		ResponseCookie cookie = ResponseCookie.from("refreshToken", newRefreshToken)
 			.httpOnly(true)
 			.secure(true)
+			.sameSite("None")
+			.domain("csalgo.co.kr")
 			.path("/")
 			.maxAge(Duration.ofDays(30))
-			.secure(true)
 			.build();
 
 		response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
@@ -226,6 +227,8 @@ public class AdminRestClient {
 		ResponseCookie cookie = ResponseCookie.from(name, "")
 			.httpOnly(true)
 			.secure(true)
+			.sameSite("None")
+			.domain("csalgo.co.kr")
 			.path("/")
 			.maxAge(0) // 즉시 만료
 			.build();

--- a/csalgo-web/src/main/java/kr/co/csalgo/web/admin/client/AdminRestClient.java
+++ b/csalgo-web/src/main/java/kr/co/csalgo/web/admin/client/AdminRestClient.java
@@ -11,6 +11,8 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestClientResponseException;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import jakarta.servlet.http.HttpServletResponse;
 import kr.co.csalgo.web.admin.dto.AdminLoginDto;
 import kr.co.csalgo.web.admin.dto.AdminRefreshDto;
@@ -24,156 +26,109 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class AdminRestClient {
 	private final RestClient restClient;
+	private final ObjectMapper objectMapper = new ObjectMapper();
 
 	/** 로그인 */
-	public ResponseEntity<AdminLoginDto.Response> login(AdminLoginDto.Request body) {
-		return restClient.post()
-			.uri("/admin/login")
-			.body(body)
-			.retrieve()
-			.toEntity(AdminLoginDto.Response.class);
+	public ResponseEntity<?> login(AdminLoginDto.Request body) {
+		return postAndHandle("/admin/login", body, AdminLoginDto.Response.class);
 	}
 
 	/** 토큰 재발급 */
-	public ResponseEntity<AdminRefreshDto.Response> refresh(AdminRefreshDto.Request body) {
-		return restClient.post()
-			.uri("/admin/refresh")
-			.body(body)
-			.retrieve()
-			.toEntity(AdminRefreshDto.Response.class);
+	public ResponseEntity<?> refresh(AdminRefreshDto.Request body) {
+		return postAndHandle("/admin/refresh", body, AdminRefreshDto.Response.class);
 	}
 
 	/** 로그아웃 */
-	public ResponseEntity<MessageResponseDto> logout(AdminRefreshDto.Request body, HttpServletResponse response) {
-		ResponseEntity<MessageResponseDto> result = restClient.post()
-			.uri("/admin/logout")
-			.body(body)
-			.retrieve()
-			.toEntity(MessageResponseDto.class);
-
-		expireCookie(response, "accessToken");
+	public ResponseEntity<?> logout(AdminRefreshDto.Request body, HttpServletResponse response) {
+		ResponseEntity<?> result = postAndHandle("/admin/logout", body, MessageResponseDto.class);
 		expireCookie(response, "refreshToken");
-
 		return result;
 	}
 
 	/** 사용자 목록 조회 */
-	public ResponseEntity<PagedResponse<UserDto.Response>> getUserList(String accessToken, String refreshToken, int page, int size,
-		HttpServletResponse response) {
+	public ResponseEntity<?> getUserList(String accessToken, String refreshToken, int page, int size, HttpServletResponse response) {
 		return executeWithRetry(
 			accessToken,
 			refreshToken,
-			token -> restClient.get()
-				.uri("/users?page={page}&size={size}", page, size)
-				.header("Authorization", "Bearer " + token)
-				.retrieve()
-				.toEntity(new ParameterizedTypeReference<PagedResponse<UserDto.Response>>() {
-				}),
+			token -> getAndHandle("/users?page={page}&size={size}",
+				new ParameterizedTypeReference<PagedResponse<UserDto.Response>>() {
+				},
+				token, page, size),
 			response
 		);
 	}
 
 	/** 사용자 상세 조회 */
-	public ResponseEntity<UserDto.Response> getUserDetail(String accessToken, String refreshToken, Long userId, HttpServletResponse response) {
+	public ResponseEntity<?> getUserDetail(String accessToken, String refreshToken, Long userId, HttpServletResponse response) {
 		return executeWithRetry(
 			accessToken,
 			refreshToken,
-			token -> restClient.get()
-				.uri("/users/{userId}", userId)
-				.header("Authorization", "Bearer " + token)
-				.retrieve()
-				.toEntity(UserDto.Response.class),
+			token -> getAndHandle("/users/{userId}", UserDto.Response.class, token, userId),
 			response
 		);
 	}
 
 	/** 사용자 권한 수정 */
-	public ResponseEntity<UserDto.Response> updateUserRole(String accessToken, String refreshToken, Long userId, UserDto.Request body,
+	public ResponseEntity<?> updateUserRole(String accessToken, String refreshToken, Long userId, UserDto.Request body,
 		HttpServletResponse response) {
 		return executeWithRetry(
 			accessToken,
 			refreshToken,
-			token -> restClient.put()
-				.uri("/users/{userId}/role", userId)
-				.header("Authorization", "Bearer " + token)
-				.body(body)
-				.retrieve()
-				.toEntity(UserDto.Response.class),
+			token -> putAndHandle("/users/{userId}/role", body, UserDto.Response.class, token, userId),
 			response
 		);
 	}
 
 	/** 사용자 삭제 */
-	public ResponseEntity<Void> deleteUser(String accessToken, String refreshToken, Long userId, HttpServletResponse response) {
+	public ResponseEntity<?> deleteUser(String accessToken, String refreshToken, Long userId, HttpServletResponse response) {
 		return executeWithRetry(
 			accessToken,
 			refreshToken,
-			token -> restClient.delete()
-				.uri("/users/{userId}", userId)
-				.header("Authorization", "Bearer " + token)
-				.retrieve()
-				.toEntity(Void.class),
+			token -> deleteAndHandle("/users/{userId}", Void.class, token, userId),
 			response
 		);
 	}
 
 	/** 문제 목록 조회 */
-	public ResponseEntity<PagedResponse<QuestonDto.Response>> getQuestionList(String accessToken, String refreshToken, int page, int size,
-		HttpServletResponse response) {
+	public ResponseEntity<?> getQuestionList(String accessToken, String refreshToken, int page, int size, HttpServletResponse response) {
 		return executeWithRetry(
 			accessToken,
 			refreshToken,
-			token -> restClient.get()
-				.uri("/questions?page={page}&size={size}", page, size)
-				.header("Authorization", "Bearer " + token)
-				.retrieve()
-				.toEntity(new ParameterizedTypeReference<PagedResponse<QuestonDto.Response>>() {
-				}),
+			token -> getAndHandle("/questions?page={page}&size={size}",
+				new ParameterizedTypeReference<PagedResponse<QuestonDto.Response>>() {
+				},
+				token, page, size),
 			response
 		);
 	}
 
 	/** 문제 상세 조회 */
-	public ResponseEntity<QuestonDto.Response> getQuestionDetail(String accessToken, String refreshToken, Long questionId,
-		HttpServletResponse response) {
+	public ResponseEntity<?> getQuestionDetail(String accessToken, String refreshToken, Long questionId, HttpServletResponse response) {
 		return executeWithRetry(
 			accessToken,
 			refreshToken,
-			token -> restClient.get()
-				.uri("/questions/{id}", questionId)
-				.header("Authorization", "Bearer " + token)
-				.retrieve()
-				.toEntity(QuestonDto.Response.class),
+			token -> getAndHandle("/questions/{id}", QuestonDto.Response.class, token, questionId),
 			response
 		);
 	}
 
 	/** 문제 수정 */
-	public ResponseEntity<MessageResponseDto> updateQuestion(String accessToken, String refreshToken, Long questionId, QuestonDto.Request body,
+	public ResponseEntity<?> updateQuestion(String accessToken, String refreshToken, Long questionId, QuestonDto.Request body,
 		HttpServletResponse response) {
 		return executeWithRetry(
 			accessToken,
 			refreshToken,
-			token -> restClient.put()
-				.uri("/questions/{id}", questionId)
-				.header("Authorization", "Bearer " + token)
-				.body(body)
-				.retrieve()
-				.toEntity(MessageResponseDto.class),
+			token -> putAndHandle("/questions/{id}", body, MessageResponseDto.class, token, questionId),
 			response
 		);
 	}
 
 	/** 문제 삭제 */
-	public ResponseEntity<MessageResponseDto> deleteQuestion(String accessToken, String refreshToken, Long questionId, HttpServletResponse response) {
+	public ResponseEntity<?> deleteQuestion(String accessToken, String refreshToken, Long questionId, HttpServletResponse response) {
 		return executeWithRetry(
 			accessToken,
 			refreshToken,
-			token -> restClient.delete()
-				.uri("/questions/{id}", questionId)
-				.header("Authorization", "Bearer " + token)
-				.retrieve()
-				.toEntity(MessageResponseDto.class),
+			token -> deleteAndHandle("/questions/{id}", MessageResponseDto.class, token, questionId),
 			response
 		);
 	}
@@ -188,38 +143,135 @@ public class AdminRestClient {
 		try {
 			return requestFn.apply(accessToken);
 		} catch (RestClientResponseException ex) {
-			// 401일 경우 Refresh 시도
 			if ((ex.getRawStatusCode() == 401) && refreshToken != null) {
-				ResponseEntity<AdminRefreshDto.Response> refreshRes =
-					this.refresh(new AdminRefreshDto.Request(refreshToken));
+				ResponseEntity<?> refreshRes = this.refresh(new AdminRefreshDto.Request(refreshToken));
 
-				if (refreshRes.getStatusCode().is2xxSuccessful() && refreshRes.getBody() != null) {
-					String newAccessToken = refreshRes.getBody().getAccessToken();
-					String newRefreshToken = refreshRes.getBody().getRefreshToken();
+				if (refreshRes.getStatusCode().is2xxSuccessful() && refreshRes.getBody() instanceof AdminRefreshDto.Response body) {
+					String newAccessToken = body.getAccessToken();
+					String newRefreshToken = body.getRefreshToken();
 
-					// 2. 새로운 RefreshToken을 쿠키에 저장
 					updateRefreshTokenCookie(response, newRefreshToken);
-
-					// 3. 새로운 AccessToken으로 재호출
 					return requestFn.apply(newAccessToken);
 				}
 			}
-			// 다른 오류는 그대로 throw
 			throw ex;
+		}
+	}
+
+	/** 공통 POST 처리 */
+	private <T, R> ResponseEntity<?> postAndHandle(String uri, T requestBody, Class<R> responseType, Object... uriVars) {
+		try {
+			return restClient.post()
+				.uri(uri, uriVars)
+				.body(requestBody)
+				.exchange((req, res) -> {
+					String body = res.bodyTo(String.class);
+					if (res.getStatusCode().is2xxSuccessful()) {
+						R dto = objectMapper.readValue(body, responseType);
+						return ResponseEntity.ok(dto);
+					} else {
+						return ResponseEntity.status(res.getStatusCode()).body(body);
+					}
+				});
+		} catch (Exception e) {
+			return ResponseEntity.internalServerError().body(e.getMessage());
+		}
+	}
+
+	/** 공통 GET 처리 */
+	private <R> ResponseEntity<?> getAndHandle(String uri, Class<R> responseType, String token, Object... uriVars) {
+		try {
+			return restClient.get()
+				.uri(uri, uriVars)
+				.header("Authorization", "Bearer " + token)
+				.exchange((req, res) -> {
+					String body = res.bodyTo(String.class);
+					if (res.getStatusCode().is2xxSuccessful()) {
+						R dto = objectMapper.readValue(body, responseType);
+						return ResponseEntity.ok(dto);
+					} else {
+						return ResponseEntity.status(res.getStatusCode()).body(body);
+					}
+				});
+		} catch (Exception e) {
+			return ResponseEntity.internalServerError().body(e.getMessage());
+		}
+	}
+
+	/** 공통 GET 처리 (제네릭 응답) */
+	private <R> ResponseEntity<?> getAndHandle(String uri, ParameterizedTypeReference<R> responseType, String token, Object... uriVars) {
+		try {
+			return restClient.get()
+				.uri(uri, uriVars)
+				.header("Authorization", "Bearer " + token)
+				.exchange((req, res) -> {
+					String body = res.bodyTo(String.class);
+					if (res.getStatusCode().is2xxSuccessful()) {
+						R dto = objectMapper.readValue(body,
+							objectMapper.getTypeFactory().constructType(responseType.getType()));
+						return ResponseEntity.ok(dto);
+					} else {
+						return ResponseEntity.status(res.getStatusCode()).body(body);
+					}
+				});
+		} catch (Exception e) {
+			return ResponseEntity.internalServerError().body(e.getMessage());
+		}
+	}
+
+	/** 공통 PUT 처리 */
+	private <T, R> ResponseEntity<?> putAndHandle(String uri, T requestBody, Class<R> responseType, String token, Object... uriVars) {
+		try {
+			return restClient.put()
+				.uri(uri, uriVars)
+				.header("Authorization", "Bearer " + token)
+				.body(requestBody)
+				.exchange((req, res) -> {
+					String body = res.bodyTo(String.class);
+					if (res.getStatusCode().is2xxSuccessful()) {
+						R dto = objectMapper.readValue(body, responseType);
+						return ResponseEntity.ok(dto);
+					} else {
+						return ResponseEntity.status(res.getStatusCode()).body(body);
+					}
+				});
+		} catch (Exception e) {
+			return ResponseEntity.internalServerError().body(e.getMessage());
+		}
+	}
+
+	/** 공통 DELETE 처리 */
+	private <R> ResponseEntity<?> deleteAndHandle(String uri, Class<R> responseType, String token, Object... uriVars) {
+		try {
+			return restClient.delete()
+				.uri(uri, uriVars)
+				.header("Authorization", "Bearer " + token)
+				.exchange((req, res) -> {
+					String body = res.bodyTo(String.class);
+					if (res.getStatusCode().is2xxSuccessful()) {
+						if (responseType == Void.class) {
+							return ResponseEntity.ok().build();
+						}
+						R dto = objectMapper.readValue(body, responseType);
+						return ResponseEntity.ok(dto);
+					} else {
+						return ResponseEntity.status(res.getStatusCode()).body(body);
+					}
+				});
+		} catch (Exception e) {
+			return ResponseEntity.internalServerError().body(e.getMessage());
 		}
 	}
 
 	/** Refresh Token 쿠키 업데이트 */
 	private void updateRefreshTokenCookie(HttpServletResponse response, String newRefreshToken) {
-		ResponseCookie cookie = ResponseCookie.from("refreshToken", newRefreshToken)
+		ResponseCookie cookie = ResponseCookie.from("refreshToken", "test")
 			.httpOnly(true)
 			.secure(true)
 			.sameSite("None")
-			.domain("csalgo.co.kr")
 			.path("/")
 			.maxAge(Duration.ofDays(30))
 			.build();
-
 		response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
 	}
 
@@ -228,9 +280,8 @@ public class AdminRestClient {
 			.httpOnly(true)
 			.secure(true)
 			.sameSite("None")
-			.domain("csalgo.co.kr")
 			.path("/")
-			.maxAge(0) // 즉시 만료
+			.maxAge(0)
 			.build();
 		response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
 	}

--- a/csalgo-web/src/main/resources/static/js/cookie.js
+++ b/csalgo-web/src/main/resources/static/js/cookie.js
@@ -1,7 +1,7 @@
 export function setCookie(name, value, days = 1) {
     const expires = new Date();
     expires.setDate(expires.getDate() + days);
-    document.cookie = `${name}=${value}; path=/; expires=${expires.toUTCString()}; SameSite=Strict; Secure`;
+    document.cookie = `${name}=test; Path=/; Expires=${expires.toUTCString()}; SameSite=None; Secure`;
 }
 
 export function getCookie(name) {
@@ -11,5 +11,5 @@ export function getCookie(name) {
 }
 
 export function deleteCookie(name) {
-    document.cookie = `${name}=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT`;
+    document.cookie = `${name}=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=None; Secure`;
 }


### PR DESCRIPTION
<!-- (title: "[Type] Title close #IssueNumber") -->

## Motivation

<!-- 작성 배경 -->

- resolve #213 

## Problem Solving

* Production 환경에서 관리자 로그인 시 520 오류 발생
* 원인: `refreshToken` 쿠키에 `SameSite` 속성이 명시되지 않아,
  `www.csalgo.co.kr` ↔ `api.csalgo.co.kr` 간 크로스 도메인 요청에서 브라우저/프록시가 쿠키를 차단
* 해결: 쿠키 설정 시 `SameSite=None; Secure` 를 명시적으로 추가하여 크로스 도메인에서도 쿠키 전달 가능하도록 수정

## To Reviewer

### ‼️ 구독 API에서는 오류가 발생하지 않고 로그인 API에서만 오류가 발생하는 이유

* 로그인 API에서만 오류가 발생한 이유는 **쿠키 헤더 전달 여부 차이**입니다
  * 로그인 API: `Set-Cookie` 포함 → SameSite 속성 누락 시 차단 → 520 오류 (cloudflare에서 체크)
  * 구독 API: 쿠키 없음 → 차단 이슈 없음 → 정상 동작

### 🔎 Cloudflare 520 동작 방식

1. 오리진 서버(BE) → 정상 응답(200 + Set-Cookie 헤더 포함)을 Cloudflare에 전달
2. Cloudflare → 응답을 파싱/검증하는데, 이때 예상치 못한 헤더가 있으면 **520으로 치환**
   * 예: 헤더 크기 제한 초과
   * 예: `Set-Cookie` 조합이 Cloudflare가 허용하지 않는 포맷 (예: `SameSite` 없는 Secure 쿠키)
   * 예: 여러 개의 `Set-Cookie` 중 유효하지 않은 값 포함
3. 브라우저는 200이 아닌 520을 보게 됨

### 😱 520 해결 후 502 발생

- 이번 502 오류는 코드 자체 문제가 아니라 **Cloudflare가 preview 도메인에서 내려오는 `Set-Cookie` 헤더를 차단**하기 때문에 발생했습니다.
- API 서버를 직접 호출할 경우 정상 동작하나, FE(Spring)에서 `Set-Cookie`를 내려주는 순간 Cloudflare에서 502로 치환됩니다.
- 따라서 **FE에서 직접 쿠키를 내려주는 방식은 preview 환경에서 사용할 수 없고**, 해결 방법은 다음 두 가지입니다:
  1. **API 서버가 직접 refreshToken 쿠키를 내려주도록 변경** (권장, 표준 방식)
  2. preview 환경에 한해 FE/JS에서 `document.cookie`로 쿠키를 직접 설정하는 임시 우회 (보안 취약)
  3. admin은 local에서만 실행 (현재 pr merge 후 추가 작업 X)
- 운영(prod) 환경에서는 API 서버 도메인에서 직접 쿠키를 내려주도록 구조를 개선하는 것이 가장 안전합니다.
- 두 방식 중 어떤 방식을 채택할 지 서연님 의견이 궁금합니다!