### PR TITLE
[Fix] 문제 수정 시 description 필드 수정 기능 추가 #216

### DIFF
--- a/csalgo-application/src/main/java/kr/co/csalgo/application/problem/usecase/UpdateQuestionUseCase.java
+++ b/csalgo-application/src/main/java/kr/co/csalgo/application/problem/usecase/UpdateQuestionUseCase.java
@@ -16,7 +16,7 @@ public class UpdateQuestionUseCase {
 	private final QuestionService questionService;
 
 	public CommonResponse updateQuestion(Long questionId, QuestionDto.Request request) {
-		questionService.update(questionId, request.getTitle(), request.getSolution());
+		questionService.update(questionId, request.getTitle(), request.getSolution(), request.getDescription());
 		return new CommonResponse(MessageCode.UPDATE_QUESTION_SUCCESS.getMessage());
 	}
 }

--- a/csalgo-application/src/test/java/kr/co/csalgo/application/problem/usecase/UpdateQuestionUseCaseTest.java
+++ b/csalgo-application/src/test/java/kr/co/csalgo/application/problem/usecase/UpdateQuestionUseCaseTest.java
@@ -31,13 +31,14 @@ class UpdateQuestionUseCaseTest {
 		QuestionDto.Request request = QuestionDto.Request.builder()
 			.title("수정된 제목")
 			.solution("수정된 풀이")
+			.description("수정된 설명")
 			.build();
 
-		doNothing().when(questionService).update(questionId, request.getTitle(), request.getSolution());
+		doNothing().when(questionService).update(questionId, request.getTitle(), request.getSolution(), request.getDescription());
 
 		CommonResponse result = updateQuestionUseCase.updateQuestion(questionId, request);
 
-		verify(questionService).update(questionId, "수정된 제목", "수정된 풀이");
+		verify(questionService).update(questionId, "수정된 제목", "수정된 풀이", "수정된 설명");
 		assertThat(result).isNotNull();
 	}
 }

--- a/csalgo-domain/src/main/java/kr/co/csalgo/domain/question/entity/Question.java
+++ b/csalgo-domain/src/main/java/kr/co/csalgo/domain/question/entity/Question.java
@@ -32,8 +32,9 @@ public class Question extends AuditableEntity {
 		this.solution = solution;
 	}
 
-	public void updateQuestion(String title, String solution) {
+	public void updateQuestion(String title, String solution, String description) {
 		this.title = title;
 		this.solution = solution;
+		this.description = description;
 	}
 }

--- a/csalgo-domain/src/main/java/kr/co/csalgo/domain/question/service/QuestionService.java
+++ b/csalgo-domain/src/main/java/kr/co/csalgo/domain/question/service/QuestionService.java
@@ -37,9 +37,9 @@ public class QuestionService {
 	}
 
 	@Transactional
-	public void update(Long id, String title, String solution) {
+	public void update(Long id, String title, String solution, String description) {
 		Question question = this.read(id);
-		question.updateQuestion(title, solution);
+		question.updateQuestion(title, solution, description);
 	}
 
 	@Transactional

--- a/csalgo-domain/src/test/java/kr/co/csalgo/domain/service/QuestionServiceTest.java
+++ b/csalgo-domain/src/test/java/kr/co/csalgo/domain/service/QuestionServiceTest.java
@@ -154,12 +154,13 @@ class QuestionServiceTest {
 		Long id = 1L;
 		String newTitle = "수정된 제목";
 		String newSolution = "수정된 풀이";
+		String newDescription = "수정된 설명";
 
 		Question question = new Question("기존 제목", "기존 설명", "기존 풀이");
 
 		when(questionRepository.findById(id)).thenReturn(Optional.of(question));
 
-		questionService.update(id, newTitle, newSolution);
+		questionService.update(id, newTitle, newSolution, newDescription);
 
 		assertThat(question.getTitle()).isEqualTo(newTitle);
 		assertThat(question.getSolution()).isEqualTo(newSolution);


### PR DESCRIPTION
<!-- (title: "[Type] Title close #IssueNumber") -->

## Motivation

<!-- 작성 배경 -->

- resolve #216 

## Problem Solving

<!-- 해결 방법 -->

- 원인:
  - `UpdateQuestionUseCase` → `QuestionService` → `Question` 엔티티까지 전달되는 파라미터에 `description` 필드가 누락되어 있었음
  - 따라서 제목(title), 풀이(solution)만 업데이트되고 설명은 기존 값이 유지됨
- 해결 방안:
  - `UpdateQuestionUseCase` 메서드 호출 시 `request.getDescription()` 전달 추가
  - `QuestionService.update` 메서드 시그니처에 `description` 파라미터 추가
  - `Question.updateQuestion` 엔티티 메서드에 description 업데이트 로직 추가
  - 관련 테스트 코드 수정

## To Reviewer

<!-- 리뷰어에게 말하고 싶은 것, 유의 깊게 봐주었으면 하는 것, 의문점 등 -->

- 없음